### PR TITLE
PP-2727 Update success URL and add catches to pact setup in tests

### DIFF
--- a/app/paths.js
+++ b/app/paths.js
@@ -11,7 +11,7 @@ module.exports = {
   },
   demoPayment: {
     complete: '/payment-complete/:paymentExternalId',
-    success: '/success',
+    success: '/successful',
     failure: '/failed'
   },
   healthcheck: {

--- a/test/unit/client/product_client/payment/create_test.js
+++ b/test/unit/client/product_client/payment/create_test.js
@@ -44,6 +44,7 @@ describe('products client - creating a new payment', () => {
     mockServer.delete()
       .then(() => pactProxy.removeAll())
       .then(() => done())
+      .catch(done)
   })
 
   describe('when a charge is successfully created', () => {
@@ -67,9 +68,7 @@ describe('products client - creating a new payment', () => {
         .catch(e => done(e))
     })
 
-    after((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should create a new product', () => {
       const plainResponse = response.getPlain()
@@ -107,9 +106,7 @@ describe('products client - creating a new payment', () => {
         })
     })
 
-    afterEach((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should reject with error unauthorised', () => {
       expect(result.errorCode).to.equal(401)
@@ -135,9 +132,7 @@ describe('products client - creating a new payment', () => {
         })
     })
 
-    afterEach(done => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should reject with error: bad request', () => {
       expect(result.errorCode).to.equal(400)

--- a/test/unit/client/product_client/payment/get_by_payment_external_id_test.js
+++ b/test/unit/client/product_client/payment/get_by_payment_external_id_test.js
@@ -44,6 +44,7 @@ describe('products client - find a payment by it\'s own external id', function (
     mockServer.delete()
       .then(() => pactProxy.removeAll())
       .then(() => done())
+      .catch(done)
   })
 
   describe('when a product is successfully found', () => {
@@ -66,9 +67,7 @@ describe('products client - find a payment by it\'s own external id', function (
         .catch(e => done(e))
     })
 
-    after((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should find an existing payment', () => {
       const plainResponse = response.getPlain()
@@ -106,9 +105,7 @@ describe('products client - find a payment by it\'s own external id', function (
         })
     })
 
-    after((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should reject with error: 401 unauthorised', () => {
       expect(result.errorCode).to.equal(401)
@@ -134,9 +131,7 @@ describe('products client - find a payment by it\'s own external id', function (
         })
     })
 
-    after((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should reject with error: 404 not found', () => {
       expect(result.errorCode).to.equal(404)

--- a/test/unit/client/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/client/product_client/payment/get_by_product_external_id_test.js
@@ -45,6 +45,7 @@ describe('products client - find a payment by it\'s associated product external 
     mockServer.delete()
       .then(() => pactProxy.removeAll())
       .then(() => done())
+      .catch(done)
   })
 
   describe('when a product is successfully found', () => {
@@ -71,9 +72,7 @@ describe('products client - find a payment by it\'s associated product external 
         .catch(e => done(e))
     })
 
-    after((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should return a list of payments', () => {
       expect(result.length).to.equal(3)
@@ -115,9 +114,7 @@ describe('products client - find a payment by it\'s associated product external 
         })
     })
 
-    after((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should reject with error: 401 unauthorised', () => {
       expect(result.errorCode).to.equal(401)
@@ -143,9 +140,7 @@ describe('products client - find a payment by it\'s associated product external 
         })
     })
 
-    after((done) => {
-      productsMock.finalize().then(() => done())
-    })
+    after(() => productsMock.finalize())
 
     it('should reject with error: 404 not found', () => {
       expect(result.errorCode).to.equal(404)


### PR DESCRIPTION
# PP-2727 Update success URL and add catches to pact setup in tests

## What
- updated `/success` to `/successful` as per design
- updated Pact `after` statements to include `Promise.catch` calls