### PR TITLE
PP-2855 add end to end test step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,11 @@ pipeline {
         }
       }
     }
+    stage('Test') {
+      steps {
+        runProductsEndToEnd("products-ui")
+      }
+    }
     stage('Docker Tag') {
       steps {
         script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     }
     stage('Test') {
       steps {
-        runProductsEndToEnd("productsui")
+        runParameterisedEndToEnd("productsui", null, "end2end-products", false, false)
       }
     }
     stage('Docker Tag') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
     }
     stage('Test') {
       steps {
-        runProductsEndToEnd("products-ui")
+        runProductsEndToEnd("productsui")
       }
     }
     stage('Docker Tag') {


### PR DESCRIPTION
This will trigger e2e tests tagged with `e2e-products`

Dropping `-` from tag name due to bash variable names not supporting `-`s. For tagging we are already not using it in pay-scripts. So using the same convention