### PR TITLE
use symlink in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN cd /tmp && npm install --production
 WORKDIR /app
 ADD . /app
 
-RUN cp -a /tmp/node_modules /app/
+RUN ln -s /tmp/node_modules /app/node_modules
 
 CMD npm start

--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -15,4 +15,4 @@ ADD package.json /tmp/package.json
 RUN cd /tmp && npm install
 WORKDIR /app
 
-CMD mkdir -p /app && cp -a /tmp/node_modules /app/ && npm run compile && npm test
+CMD rm -rf node_modules && ln -s /tmp/node_modules /app/node_modules && npm run compile && npm test && rm -rf node_modules


### PR DESCRIPTION
## What
- Use symlink rather than directory copy for node_modules caching layer in dockerfiles

## Why
- Speeds up the docker image build process both for the test image and the deploy image
- Makes the images smaller too