### PR TITLE
PP-2997 Regular Expression Denial of Service security issue of servefavicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "qs": "^6.4.0",
     "readdir": "0.0.13",
     "requestretry": "^1.12.0",
-    "serve-favicon": "2.4.3",
+    "serve-favicon": "2.4.5",
     "sleep": "^5.1.1",
     "staticify": "0.0.8",
     "throng": "4.0.x",


### PR DESCRIPTION
There is a security issue reported by Snyk about serve-favicon@2.4.3. Recommended fix is to upgrade to serve-favicon@2.4.5.

- https://snyk.io/test/npm/serve-favicon/2.4.3?severity=high&severity=medium&severity=low