### PR TITLE
PP-2996 Trigger products to deploy both on PaaS as well as AWS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ pipeline {
   agent any
 
   options {
-    ansiColor('xterm')
     timestamps()
   }
 
@@ -42,6 +41,7 @@ pipeline {
       }
       steps {
         deployPaas("products-ui", "test", null, true)
+        deploy("products-ui", "test", null, true, false, "uk.gov.pay.endtoend.categories.SmokeProducts")
       }
     }
   }


### PR DESCRIPTION
This needs to be done until we fully migrate over to AWS.

At the same time remove the ansiColor trigger which is disabled in jenkins