### PR TITLE
PP-3035 Add product.serviceName to nav

### DIFF
--- a/app/assets/sass/template/header.scss
+++ b/app/assets/sass/template/header.scss
@@ -49,10 +49,6 @@
 }
 
 #global-header .header-proposition {
-  /* Trick to align the proposition menu to the right of the header */
-  @include media(desktop) {
-    text-align: right;
-  }
 
   /* Styles below make the header style match the product page */
   a.menu {

--- a/app/controllers/demo_payment/payment_success_controller.js
+++ b/app/controllers/demo_payment/payment_success_controller.js
@@ -13,8 +13,4 @@ const data = {
   exampleImgSrc: staticify.getVersionedPath('/images/confirmation-page.png')
 }
 
-module.exports = (req, res) => {
-  res
-    .status(200)
-    .render(CONFIRM_SUCCESS_VIEW, data)
-}
+module.exports = (req, res) => res.status(200).render(CONFIRM_SUCCESS_VIEW, data)

--- a/app/middleware/resolve_payment.js
+++ b/app/middleware/resolve_payment.js
@@ -9,6 +9,7 @@ module.exports = function (req, res, next) {
   productsClient.payment.getByPaymentExternalId(paymentExternalId)
     .then(payment => {
       req.payment = payment
+      res.locals.payment = payment
       next()
     })
     .catch(err => {

--- a/app/middleware/resolve_product.js
+++ b/app/middleware/resolve_product.js
@@ -9,6 +9,7 @@ module.exports = function (req, res, next) {
   productsClient.product.getByProductExternalId(productExternalId)
     .then(product => {
       req.product = product
+      res.locals.product = product
       next()
     })
     .catch(err => {

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -12,6 +12,7 @@ const lodash = require('lodash')
  * @property {string} description
  * @property {string} returnUrl
  * @property {string} govukStatus - the current status of the gov.uk pay charge
+ * @property {string} serviceName - the name of the service with which the product is associated
  * @property {object} links
  * @property {object} links.pay
  * @property {string} links.pay.href - url to use to create a payment for the product
@@ -29,6 +30,7 @@ class Product {
    * @param {string} opts.name - The name of the product
    * @param {number} opts.price - price of the product in pence
    * @param {string} opts.govuk_status - the current status of the gov.uk pay charge
+   * @param {string} opts.service_name - the name of the service with which the product is associated
    * @param {Object[]} opts._links - links for the product ('self' to re-GET this product from the server, and 'pay' to create a payment for this product)
    * @param {string} opts._links[].href - url of the link
    * @param {string} opts._links[].method - the http method of the link
@@ -42,6 +44,7 @@ class Product {
     this.name = opts.name
     this.price = opts.price
     this.govukStatus = opts.govuk_status
+    this.serviceName = opts.service_name || 'Example Service Name'
     this.description = opts.description
     this.returnUrl = opts.return_url
     opts._links.forEach(link => lodash.set(this, `links.${link.rel}`, {method: link.method, href: link.href}))

--- a/app/utils/proxy.js
+++ b/app/utils/proxy.js
@@ -13,19 +13,16 @@ const originalHttpsRequest = https.request
 // requests will pick them up do a bad job around certificate handling.
 function captureEnvironment () {
   if (process.env.HTTPS_PROXY) {
-    console.log('Tunnelling HTTPS -> ', process.env.HTTPS_PROXY)
     process.env.TUNNEL_HTTPS_PROXY = process.env.HTTPS_PROXY
     delete process.env.HTTPS_PROXY
   }
 
   if (process.env.HTTP_PROXY) {
-    console.log('Tunnelling HTTP -> ', process.env.HTTP_PROXY)
     process.env.TUNNEL_HTTP_PROXY = process.env.HTTP_PROXY
     delete process.env.HTTP_PROXY
   }
 
   if (process.env.NO_PROXY) {
-    console.log('No proxy zones: ', process.env.NO_PROXY)
     process.env.TUNNEL_NO_PROXY = process.env.NO_PROXY
     delete process.env.NO_PROXY
   }

--- a/app/views/includes/propositional_navigation.njk
+++ b/app/views/includes/propositional_navigation.njk
@@ -1,0 +1,7 @@
+<div class="header-proposition">
+  <div class="content">
+    <nav id="proposition-menu">
+      <span id="proposition-name">{{ product.serviceName }}</span>
+    </nav>
+  </div>
+</div>

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -6,28 +6,33 @@
 {% block page_title %}GOV.UK Pay{% endblock %}
 
 {% block head %}
-  {% include "includes/head.njk" %}
+    {% include "includes/head.njk" %}
 {% endblock %}
 
 {% block cookie_message %}
-{% include "includes/cookies.njk" %}
+    {% include "includes/cookies.njk" %}
 {% endblock %}
 
+{% block proposition_header %}
+    {% include "includes/propositional_navigation.njk" %}
+{% endblock %}
+{% block header_class %}with-proposition{% endblock %}
+
 {% block content %}
-<main id="content" role="main">
-  {% block full_width_content %}{% endblock %}
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      {% block main_content %}{% endblock %}
+  <main id="content" role="main">
+      {% block full_width_content %}{% endblock %}
+    <div class="grid-row">
+      <div class="column-two-thirds">
+          {% block main_content %}{% endblock %}
+      </div>
     </div>
-  </div>
-</main>
+  </main>
 {% endblock %}
 
 {% block footer_top %}
-  {% include "includes/footer-categories.njk" %}
+    {% include "includes/footer-categories.njk" %}
 {% endblock %}
 
 {% block footer_support_links %}
-  {% include "includes/footer-support-links.njk" %}
+    {% include "includes/footer-support-links.njk" %}
 {% endblock %}

--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -15,4 +15,4 @@ ADD package.json /tmp/package.json
 RUN cd /tmp && npm install
 WORKDIR /app
 ENV LD_LIBRARY_PATH /app/node_modules/appmetrics
-CMD rm -rf node_modules && ln -s /tmp/node_modules /app/node_modules && npm run compile && npm run lint && npm test -- --forbid-only --forbid-pending && rm -rf node_modules
+CMD rm -rf node_modules && ln -s /tmp/node_modules /app/node_modules && npm run compile && npm run lint && npm run test-with-coverage -- --forbid-only --forbid-pending && rm -rf node_modules

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "watch-live-reload": "./node_modules/.bin/grunt watch",
     "lint": "./node_modules/.bin/standard",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
-    "test": "node ./node_modules/nyc/bin/nyc node ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests)'.js",
+    "test-with-coverage": "node ./node_modules/nyc/bin/nyc npm test",
+    "test": "node ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests)'.js",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },

--- a/test/unit/middleware/resolve_payment_test.js
+++ b/test/unit/middleware/resolve_payment_test.js
@@ -12,8 +12,8 @@ const Payment = require('../../../app/models/Payment.class')
 const productFixtures = require('../../fixtures/product_fixtures')
 const resolvePayment = require('../../../app/middleware/resolve_payment')
 
-describe('resolve product middleware', () => {
-  describe('when the product exists', () => {
+describe('resolve payment middleware', () => {
+  describe('when the payment exists', () => {
     let req, res, next, payment
 
     before(done => {
@@ -21,6 +21,7 @@ describe('resolve product middleware', () => {
       nock(config.PRODUCTS_URL).get(`/v1/api/payments/${payment.external_id}`).reply(200, payment)
       req = {}
       res = {
+        locals: {},
         status: sinon.spy(),
         setHeader: sinon.spy(),
         render: sinon.spy(() => done(new Error('Resolve payment middleware unexpectedly rendered a page')))
@@ -34,7 +35,7 @@ describe('resolve product middleware', () => {
       nock.cleanAll()
     })
 
-    it(`should set 'req.product' equal to the returned Product`, () => {
+    it(`should set 'req.product' equal to the returned Payment`, () => {
       expect(req).to.have.property('payment').to.deep.equal(new Payment(payment))
     })
 

--- a/test/unit/middleware/resolve_product_test.js
+++ b/test/unit/middleware/resolve_product_test.js
@@ -21,6 +21,7 @@ describe('resolve product middleware', () => {
       nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
       req = {}
       res = {
+        locals: {},
         status: sinon.spy(),
         setHeader: sinon.spy(),
         render: sinon.spy(() => done(new Error('Resolve product middleware unexpectedly rendered a page')))


### PR DESCRIPTION
# PP-3035 Add `product.serviceName` to nav
- adds `serviceName` to `Product` class
- adds `product` and `payment` to `res.locals`
- adds `product.serviceName` to proposition header
- moves nyc to separate `npm run test-with-coverage`
- removes unneeded console.logs from `proxy.js`