### PR TITLE
PP-3034 Fix for not displaying the flash error messages

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -32,7 +32,8 @@ $grey-8: #fff;
 // Overrides
 @import "gov-uk-overrides/_grid";
 
-// Pages
+// Modules
 @import "modules/demo-confirmation";
 @import "modules/currency-input";
 @import "modules/input-confirm";
+@import "modules/flash";

--- a/app/assets/sass/modules/_flash.scss
+++ b/app/assets/sass/modules/_flash.scss
@@ -1,0 +1,24 @@
+.notification {
+  @include core-19;
+  margin-bottom: $gutter;
+  padding: $gutter $gutter / 2;
+  border: 5px solid $green;
+
+  h2 {
+    margin: 0 0 em(20, 24);
+    @include core-24;
+    font-weight: bold;
+  }
+
+  p:only-child {
+    margin-bottom: 0;
+  }
+}
+
+.generic-error {
+  border-color: $red;
+}
+
+.error-summary ul {
+  list-style: none;
+}

--- a/app/controllers/adhoc_payment/get_amount_controller.js
+++ b/app/controllers/adhoc_payment/get_amount_controller.js
@@ -13,6 +13,11 @@ module.exports = (req, res) => {
     serviceName: product.serviceName,
     productExternalId: product.externalId
   }
+  if (req.errorMessage) {
+    data.flash = {
+      genericError: req.errorMessage
+    }
+  }
 
   logger.info(`[${correlationId}] getting amount for product payment ${product.externalId}`)
   response(req, res, 'adhoc-payment/amount', data)

--- a/app/controllers/adhoc_payment/submit_amount_controller.js
+++ b/app/controllers/adhoc_payment/submit_amount_controller.js
@@ -12,10 +12,10 @@ module.exports = (req, res) => {
   let paymentAmount = req.body['payment-amount']
 
   if (!paymentAmount || isCurrency(paymentAmount)) {
-    req.flash('genericError', `<h2>Use valid characters only</h2> ${isCurrency(paymentAmount)}`)
+    req.errorMessage = `<h2>${isCurrency(paymentAmount)}</h2>`
     getAmount(req, res)
   } else if (isAboveMaxAmount(paymentAmount)) {
-    req.flash('genericError', `<h2>Enter a valid amount</h2> ${isAboveMaxAmount(paymentAmount)}`)
+    req.errorMessage = `<h2>${isAboveMaxAmount(paymentAmount)}</h2>`
     getAmount(req, res)
   } else {
     paymentAmount = paymentAmount.replace(/[^0-9.-]+/g, '')

--- a/app/views/includes/flash.njk
+++ b/app/views/includes/flash.njk
@@ -1,0 +1,18 @@
+{% block flash %}
+<div class="grid-row">
+  {% if flash.genericError %}
+  <div class="column-two-thirds flash-container">
+    <div class="notification generic-error">
+      {{ flash.genericError | safe }}
+    </div>
+  </div>
+  {% endif %}
+  {% if flash.generic %}
+  <div class="column-two-thirds flash-container">
+    <div class="notification generic-flash">
+      {{ flash.generic | safe }}
+    </div>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -20,7 +20,8 @@
 
 {% block content %}
   <main id="content" class="pad-bottom" role="main">
-      {% block full_width_content %}{% endblock %}
+    {% include "includes/flash.njk" %}
+    {% block full_width_content %}{% endblock %}
     <div class="grid-row">
       <div class="column-two-thirds">
           {% block main_content %}{% endblock %}

--- a/server.js
+++ b/server.js
@@ -138,12 +138,12 @@ function listen () {
 function initialise () {
   const app = unconfiguredApp
   app.disable('x-powered-by')
-  app.use(flash())
   initialiseTLS(app)
   initialiseProxy(app)
   initialiseCookies(app)
-
   initialiseGlobalMiddleware(app)
+
+  app.use(flash())
   initialiseTemplateEngine(app)
   initialiseRoutes(app)
   initialisePublic(app)

--- a/test/unit/controllers/adhoc_payment/submit_amount_controller_test.js
+++ b/test/unit/controllers/adhoc_payment/submit_amount_controller_test.js
@@ -3,15 +3,16 @@ const chai = require('chai')
 const config = require('../../../../config')
 const nock = require('nock')
 const csrf = require('csrf')
+const cheerio = require('cheerio')
 const supertest = require('supertest')
 const {getApp} = require('../../../../server')
 const {getMockSession, createAppWithSession} = require('../../../test_helpers/mock_session')
 const productFixtures = require('../../../fixtures/product_fixtures')
 const paths = require('../../../../app/paths')
 const expect = chai.expect
-let product, payment, response, session
+let product, payment, response, session, $
 
-describe('adhoc payment submit-amount controller', function () {
+describe.only('adhoc payment submit-amount controller', function () {
   afterEach(() => {
     nock.cleanAll()
   })
@@ -66,6 +67,7 @@ describe('adhoc payment submit-amount controller', function () {
         })
         .end((err, res) => {
           response = res
+          $ = cheerio.load(res.text || '')
           done(err)
         })
     })
@@ -75,9 +77,7 @@ describe('adhoc payment submit-amount controller', function () {
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal(`<h2>Use valid characters only</h2> Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”`)
+      expect($('.generic-error').text()).to.include(`Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”`)
     })
   })
 
@@ -95,6 +95,7 @@ describe('adhoc payment submit-amount controller', function () {
         })
         .end((err, res) => {
           response = res
+          $ = cheerio.load(res.text || '')
           done(err)
         })
     })
@@ -104,9 +105,7 @@ describe('adhoc payment submit-amount controller', function () {
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal(`<h2>Use valid characters only</h2> Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”`)
+      expect($('.generic-error').text()).to.include(`Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”`)
     })
   })
 
@@ -115,7 +114,7 @@ describe('adhoc payment submit-amount controller', function () {
       product = productFixtures.validCreateProductResponse({type: 'ADHOC'}).getPlain()
       nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
       session = getMockSession()
-      const bigAmount = '10000000.50'
+      const bigAmount = '100000000.50'
       supertest(createAppWithSession(getApp(), session))
         .post(paths.adhocPayment.amount.replace(':productExternalId', product.external_id))
         .send({
@@ -124,6 +123,7 @@ describe('adhoc payment submit-amount controller', function () {
         })
         .end((err, res) => {
           response = res
+          $ = cheerio.load(res.text || '')
           done(err)
         })
     })
@@ -133,9 +133,7 @@ describe('adhoc payment submit-amount controller', function () {
     })
 
     it('should add a relevant error message to the session \'flash\'', () => {
-      expect(session.flash).to.have.property('genericError')
-      expect(session.flash.genericError.length).to.equal(1)
-      expect(session.flash.genericError[0]).to.equal(`<h2>Enter a valid amount</h2> Choose an amount under £10,000,000`)
+      expect($('.generic-error').text()).to.include(`Choose an amount under £10,000,000`)
     })
   })
 })

--- a/test/unit/controllers/adhoc_payment/submit_amount_controller_test.js
+++ b/test/unit/controllers/adhoc_payment/submit_amount_controller_test.js
@@ -12,7 +12,7 @@ const paths = require('../../../../app/paths')
 const expect = chai.expect
 let product, payment, response, session, $
 
-describe.only('adhoc payment submit-amount controller', function () {
+describe('adhoc payment submit-amount controller', function () {
   afterEach(() => {
     nock.cleanAll()
   })


### PR DESCRIPTION
Hacky fix. Its seems `connect-flash` only works well when `req.flash` followed by a `res.redirect()`. so here making explicit flash message on output data to trigger the error message display.