### PR TITLE
PP-3252 Make certsloader more tolerant

### DIFF
--- a/app/utils/custom_certificate.js
+++ b/app/utils/custom_certificate.js
@@ -24,9 +24,13 @@ exports.addCertsToAgent = agentOptions => {
   }
 
   agentOptions.ca = agentOptions.ca || []
-  fs.readdirSync(certsPath).forEach(
-    (certPath) => agentOptions.ca.push(
-      fs.readFileSync(path.join(certsPath, certPath))
-    )
-  )
+    // Read everything from the certificates directories
+    // Get everything that isn't a directory (e.g. files, symlinks)
+    // Read it (assume it is a certificate)
+    // Add it to the agentOptions list of CAs
+  fs.readdirSync(certsPath)
+      .map(certPath => path.join(certsPath, certPath))
+      .filter(fullCertPath => !fs.lstatSync(fullCertPath).isDirectory())
+      .map(fullCertPath => fs.readFileSync(fullCertPath))
+      .forEach(ca => agentOptions.ca.push(ca))
 }


### PR DESCRIPTION
We have made some changes to certs dir on boxes, which means it may
contain sub dirs. The loader as is broke if it encounter a sub dir.
This fixes that.