### PR TITLE
PP-3252 Use pay base image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6.12.2-alpine
+FROM govukpay/nodejs:6.12.2
 
 RUN apk update &&\
     apk upgrade &&\

--- a/docker/build_and_test.Dockerfile
+++ b/docker/build_and_test.Dockerfile
@@ -1,14 +1,14 @@
-FROM node:6.12.2-alpine
+FROM govukpay/nodejs:6.12.2
 
 RUN apk update &&\
     apk upgrade &&\
-    apk add --update bash python make g++ ruby openssl
+    apk add --update bash ruby
 
 ADD docker/sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 
 RUN apk --no-cache add ca-certificates
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.25-r0/glibc-2.25-r0.apk
-RUN apk add glibc-2.25-r0.apk
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.26-r0/glibc-2.26-r0.apk
+RUN apk del libc6-compat && apk add glibc-2.26-r0.apk
 
 # add package.json before source for node_module cache layer
 ADD package.json /tmp/package.json


### PR DESCRIPTION
Use the GOV.UK Pay Node Base Image, because: 
1) its consistent 
2) its safer 
3) it has chamber in it meaning we can continue the process of ECSification.