### PR TITLE
PP-3441 Updated `product-client` following to API breaking change

### DIFF
--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -75,10 +75,7 @@ function getProductByExternalId (externalProductId) {
 function getProductsByGatewayAccountId (gatewayAccountId) {
   return baseClient.get({
     baseUrl,
-    url: '/products',
-    qs: {
-      gatewayAccountId
-    },
+    url: `/gateway-account/${gatewayAccountId}/products`,
     description: 'find a list products associated with a gateway account',
     service: SERVICE_NAME
   }).then(products => products.map(product => new Product(product)))

--- a/test/unit/client/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/client/product_client/product/get_by_gateway_account_id_test.js
@@ -11,7 +11,7 @@ const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_bu
 const productFixtures = require('../../../../fixtures/product_fixtures')
 
 // Constants
-const PRODUCT_RESOURCE = '/v1/api/products'
+const API_RESOURCE = '/v1/api'
 const mockPort = Math.floor(Math.random() * 65535)
 const mockServer = pactProxy.create('localhost', mockPort)
 let productsMock, response, result, gatewayAccountId
@@ -54,8 +54,7 @@ describe('products client - find products associated with a particular gateway a
         productFixtures.validCreateProductResponse({gateway_account_id: gatewayAccountId}),
         productFixtures.validCreateProductResponse({gateway_account_id: gatewayAccountId})
       ]
-      const interaction = new PactInteractionBuilder(PRODUCT_RESOURCE)
-        .withQuery('gatewayAccountId', String(gatewayAccountId))
+      const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
         .withUponReceiving('a valid get product by gateway account id request')
         .withMethod('GET')
         .withStatusCode(200)
@@ -97,8 +96,7 @@ describe('products client - find products associated with a particular gateway a
     before(done => {
       const productsClient = getProductsClient()
       gatewayAccountId = 98765
-      const interaction = new PactInteractionBuilder(PRODUCT_RESOURCE)
-        .withQuery('gatewayAccountId', String(gatewayAccountId))
+      const interaction = new PactInteractionBuilder(`${API_RESOURCE}/gateway-account/${gatewayAccountId}/products`)
         .withUponReceiving('a valid get product by gateway account id where the gateway account has no products')
         .withMethod('GET')
         .withStatusCode(404)


### PR DESCRIPTION
Updated `product-client` following to API breaking change in `pay-products`.

While retrieving all products by gateway account, the gateway account is now provided on the resource path instead of as a query param.