### PR TITLE
PP-3308 Redirect friendly url

### DIFF
--- a/app/controllers/friendly_url_redirect_controller.js
+++ b/app/controllers/friendly_url_redirect_controller.js
@@ -1,0 +1,26 @@
+'use strict'
+
+// Node.js core dependencies
+const logger = require('winston')
+
+// Custom dependencies
+const productsClient = require('../services/clients/products_client')
+const response = require('../utils/response')
+const errorResponse = response.renderErrorView
+
+// Constants
+const messages = {
+  internalError: 'We are unable to process your request at this time'
+}
+
+module.exports = (req, res) => {
+  const {serviceNamePath, productNamePath} = req.params
+  productsClient.product.getByProductPath(serviceNamePath, productNamePath)
+    .then(product => {
+      logger.info(`Redirecting to ${product.links.pay.href}`)
+      return res.redirect(product.links.pay.href)
+    })
+    .catch(err => {
+      return errorResponse(req, res, messages.internalError, err.errorCode || 500)
+    })
+}

--- a/app/paths.js
+++ b/app/paths.js
@@ -6,6 +6,9 @@ module.exports = {
   default: {
     index: '/'
   },
+  friendlyUrl: {
+    redirect: '/redirect/:serviceNamePath/:productNamePath'
+  },
   pay: {
     product: '/pay/:productExternalId',
     complete: '/payment-complete/:paymentExternalId'

--- a/app/routes.js
+++ b/app/routes.js
@@ -8,6 +8,7 @@ const paths = require('./paths.js')
 // - Controllers
 const staticCtrl = require('./controllers/static_controller')
 const healthcheckCtrl = require('./controllers/healthcheck_controller')
+const friendlyUrlRedirectCtrl = require('./controllers/friendly_url_redirect_controller')
 const prePaymentCtrl = require('./controllers/pre_payment_controller')
 const completeCtrl = require('./controllers/payment_complete_controller')
 const failedCtrl = require('./controllers/demo_payment/payment_failed_controller')
@@ -22,7 +23,8 @@ const resolvePaymentAndProduct = require('./middleware/resolve_payment_and_produ
 const correlationId = require('./middleware/correlation_id')
 
 // Assignments
-const {healthcheck, staticPaths, pay, demoPayment} = paths
+const {healthcheck, staticPaths, friendlyUrl, pay, demoPayment} = paths
+
 
 // Exports
 module.exports.generateRoute = generateRoute
@@ -39,6 +41,9 @@ module.exports.bind = function (app) {
 
   // STATIC
   app.all(staticPaths.naxsiError, staticCtrl.naxsiError)
+
+  // FRIENDLY URL
+  app.get(friendlyUrl.redirect, friendlyUrlRedirectCtrl)
 
   // CREATE PAYMENT
   app.get(pay.product, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, prePaymentCtrl)

--- a/app/routes.js
+++ b/app/routes.js
@@ -25,7 +25,6 @@ const correlationId = require('./middleware/correlation_id')
 // Assignments
 const {healthcheck, staticPaths, friendlyUrl, pay, demoPayment} = paths
 
-
 // Exports
 module.exports.generateRoute = generateRoute
 module.exports.paths = paths

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -18,6 +18,7 @@ module.exports = {
     create: createProduct,
     disable: disableProduct,
     getByProductExternalId: getProductByExternalId,
+    getByProductPath: getProductByPath,
     getByGatewayAccountId: getProductsByGatewayAccountId
   },
   payment: {
@@ -64,6 +65,20 @@ function getProductByExternalId (externalProductId) {
     baseUrl,
     url: `/products/${externalProductId}`,
     description: `find a product by it's external id`,
+    service: SERVICE_NAME
+  }).then(product => new Product(product))
+}
+
+/**
+ * @param {String} serviceNamePath: the service name path of the product you wish to retrieve
+ * @param {String} productNamePath: the product name path of the product you wish to retrieve
+ * @returns {Promise<Product>}
+ */
+function getProductByPath (serviceNamePath, productNamePath) {
+  return baseClient.get({
+    baseUrl,
+    url: `/products?serviceNamePath=${serviceNamePath}&productNamePath=${productNamePath}`,
+    description: `find a product by it's product path`,
     service: SERVICE_NAME
   }).then(product => new Product(product))
 }

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -83,6 +83,8 @@ module.exports = {
     }
     if (opts.description) data.description = opts.description
     if (opts.return_url) data.return_url = opts.return_url
+    if (opts.service_name_path) data.service_name_path = opts.service_name_path
+    if (opts.product_name_path) data.product_name_path = opts.product_name_path
     if (!data._links) {
       data._links = [{
         href: `http://products.url/v1/api/products/${data.external_id}`,

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -22,6 +22,8 @@ module.exports = {
     }
     if (opts.description) data.description = opts.description
     if (opts.returnUrl) data.return_url = opts.returnUrl
+    if (opts.service_name_path) data.service_name_path = opts.service_name_path
+    if (opts.product_name_path) data.product_name_path = opts.product_name_path
     return {
       getPactified: () => {
         return pactProducts.pactify(data)
@@ -91,6 +93,13 @@ module.exports = {
         rel: 'pay',
         method: 'GET'
       }]
+      if (opts.service_name_path && opts.product_name_path) {
+        data._links.push({
+          href: `http://products-ui.url/redirect/${opts.service_name_path}/${opts.product_name_path}`,
+          rel: 'friendly',
+          method: 'GET'
+        })
+      }
     }
 
     return {

--- a/test/unit/client/product_client/product/get_by_product_path_test.js
+++ b/test/unit/client/product_client/product/get_by_product_path_test.js
@@ -1,0 +1,136 @@
+'use strict'
+
+// NPM dependencies
+const Pact = require('pact')
+const {expect} = require('chai')
+const proxyquire = require('proxyquire')
+
+// Custom dependencies
+const pactProxy = require('../../../../test_helpers/pact_proxy')
+const PactInteractionBuilder = require('../../../../fixtures/pact_interaction_builder').PactInteractionBuilder
+const productFixtures = require('../../../../fixtures/product_fixtures')
+
+// Constants
+const PRODUCT_RESOURCE = '/v1/api/products'
+const mockPort = Math.floor(Math.random() * 65535)
+const mockServer = pactProxy.create('localhost', mockPort)
+let productsMock, response, result, productExternalId, serviceNamePath, productNamePath
+
+function getProductsClient (baseUrl = `http://localhost:${mockPort}`) {
+  return proxyquire('../../../../../app/services/clients/products_client', {
+    '../../../config': {
+      PRODUCTS_URL: baseUrl
+    }
+  })
+}
+
+describe('products client - find a product by it\'s product path', function () {
+  /**
+   * Start the server and set up Pact
+   */
+  before(function (done) {
+    this.timeout(5000)
+    mockServer.start().then(function () {
+      productsMock = Pact({consumer: 'Selfservice-find-product', provider: 'products', port: mockPort})
+      done()
+    })
+  })
+
+  /**
+   * Remove the server and publish pacts to broker
+   */
+  after(done => {
+    mockServer.delete()
+      .then(() => pactProxy.removeAll())
+      .then(() => done())
+  })
+
+  describe('when a product is successfully found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      productExternalId = 'existing-id'
+      serviceNamePath = 'service-name-path'
+      productNamePath = 'product-name-path'
+      response = productFixtures.validCreateProductResponse({
+        external_id: productExternalId,
+        price: 1000,
+        name: 'A Product Name',
+        description: 'About this product',
+        return_url: 'https://example.gov.uk',
+        service_name_path: serviceNamePath,
+        product_name_path: productNamePath
+      })
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
+          .withQuery('serviceNamePath', serviceNamePath)
+          .withQuery('productNamePath', productNamePath)
+          .withUponReceiving('a valid get product request')
+          .withMethod('GET')
+          .withStatusCode(200)
+          .withResponseBody(response.getPactified())
+          .build()
+      )
+        .then(() => productsClient.product.getByProductPath(serviceNamePath, productNamePath))
+        .then(res => {
+          result = res
+          done()
+        })
+        .catch(e => done(e))
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should find an existing product', () => {
+      const plainResponse = response.getPlain()
+      expect(result.externalId).to.equal(productExternalId)
+      expect(result.name).to.exist.and.equal(plainResponse.name)
+      expect(result.description).to.exist.and.equal(plainResponse.description)
+      expect(result.price).to.exist.and.equal(plainResponse.price)
+      expect(result.returnUrl).to.exist.and.equal(plainResponse.return_url)
+      expect(result).to.have.property('links')
+      expect(Object.keys(result.links).length).to.equal(3)
+      expect(result.links).to.have.property('self')
+      expect(result.links.self).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'self').method)
+      expect(result.links.self).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'self').href)
+      expect(result.links).to.have.property('pay')
+      expect(result.links.pay).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'pay').method)
+      expect(result.links.pay).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'pay').href)
+      expect(result.links).to.have.property('friendly')
+      expect(result.links.friendly).to.have.property('method').to.equal(plainResponse._links.find(link => link.rel === 'friendly').method)
+      expect(result.links.friendly).to.have.property('href').to.equal(plainResponse._links.find(link => link.rel === 'friendly').href)
+    })
+  })
+
+  describe('when a product is not found', () => {
+    before(done => {
+      const productsClient = getProductsClient()
+      serviceNamePath = 'non-existing-service-name-path'
+      productNamePath = 'non-existing-product-name-path'
+      productsMock.addInteraction(
+        new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
+          .withQuery('serviceNamePath', serviceNamePath)
+          .withQuery('productNamePath', productNamePath)
+          .withUponReceiving('a valid find product request with non existing product path')
+          .withMethod('GET')
+          .withStatusCode(404)
+          .build()
+      )
+        .then(() => productsClient.product.getByProductPath(serviceNamePath, productNamePath), done)
+        .then(() => done(new Error('Promise unexpectedly resolved')))
+        .catch((err) => {
+          result = err
+          done()
+        })
+    })
+
+    after((done) => {
+      productsMock.finalize().then(() => done())
+    })
+
+    it('should reject with error: 404 not found', () => {
+      expect(result.errorCode).to.equal(404)
+    })
+  })
+})

--- a/test/unit/controllers/adhoc_payment/post_index_controller_test.js
+++ b/test/unit/controllers/adhoc_payment/post_index_controller_test.js
@@ -12,7 +12,7 @@ const paths = require('../../../../app/paths')
 const expect = chai.expect
 let product, payment, response, session, $
 
-describe.only('adhoc payment submit-amount controller', function () {
+describe('adhoc payment submit-amount controller', function () {
   afterEach(() => {
     nock.cleanAll()
   })
@@ -69,7 +69,6 @@ describe.only('adhoc payment submit-amount controller', function () {
           .end((err, res) => {
             response = res
             $ = cheerio.load(res.text || '')
-            console.log(`${$.html()}`)
             done(err)
           })
       })

--- a/test/unit/controllers/friendly_url_redirect_controller_test.js
+++ b/test/unit/controllers/friendly_url_redirect_controller_test.js
@@ -19,8 +19,8 @@ describe('friendly url redirect controller', function () {
   describe(`when the friendly URL can be resolved to a product`, () => {
     before(done => {
       product = productFixtures.validCreateProductResponse({
-        type: 'ADHOC', 
-        service_name_path: 'service-name-path', 
+        type: 'ADHOC',
+        service_name_path: 'service-name-path',
         product_name_path: 'product-name-path'
       }).getPlain()
       nock(config.PRODUCTS_URL)

--- a/test/unit/controllers/friendly_url_redirect_controller_test.js
+++ b/test/unit/controllers/friendly_url_redirect_controller_test.js
@@ -1,0 +1,75 @@
+'use strict'
+
+const chai = require('chai')
+const config = require('../../../config')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const supertest = require('supertest')
+const {getApp} = require('../../../server')
+const {createAppWithSession} = require('../../test_helpers/mock_session')
+const productFixtures = require('../../fixtures/product_fixtures')
+const paths = require('../../../app/paths')
+const expect = chai.expect
+let product, response, $
+describe('friendly url redirect controller', function () {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe(`when the friendly URL can be resolved to a product`, () => {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC', 
+        service_name_path: 'service-name-path', 
+        product_name_path: 'product-name-path'
+      }).getPlain()
+      nock(config.PRODUCTS_URL)
+        .get(`/v1/api/products`)
+        .query({'serviceNamePath': product.service_name_path, 'productNamePath': product.product_name_path})
+        .reply(200, product)
+
+      supertest(createAppWithSession(getApp()))
+        .get(paths.friendlyUrl.redirect
+          .replace(':serviceNamePath', product.service_name_path)
+          .replace(':productNamePath', product.product_name_path))
+        .end((err, res) => {
+          response = res
+          done(err)
+        })
+    })
+    it('should redirect with code: 302', () => {
+      expect(response.statusCode).to.equal(302)
+    })
+    it('should redirect to friendly URL', () => {
+      expect(response.header).property('location').to.equal(product._links.find(link => link.rel === 'pay').href)
+    })
+  })
+
+  describe(`when the friendly URL can not be resolved to a product`, () => {
+    const serviceNamePath = 'unknown-service-name-path'
+    const productNamePath = 'unknown-product-name-path'
+    before(done => {
+      nock(config.PRODUCTS_URL)
+        .get(`/v1/api/products`)
+        .query({'serviceNamePath': serviceNamePath, 'productNamePath': productNamePath})
+        .reply(404)
+
+      supertest(createAppWithSession(getApp()))
+        .get(paths.friendlyUrl.redirect
+          .replace(':serviceNamePath', serviceNamePath)
+          .replace(':productNamePath', productNamePath))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+    it('should respond with code of 404', () => {
+      expect(response.statusCode).to.equal(404)
+    })
+    it('should render error page', () => {
+      expect($('.page-title').text()).to.equal('An error occurred:')
+      expect($('#errorMsg').text()).to.equal('We are unable to process your request at this time')
+    })
+  })
+})


### PR DESCRIPTION
* New method in product client that offers the ability to retrieve a product by product path. The payload of the product response has also been updated to handle the additional friendly url link.
* New controller that handles a `friendly URL` by retrieving the product associated to the `service name path` and `product name path` and redirecting to the `pay URL`.