### PR TITLE
PP-3510 - display description line breaks

### DIFF
--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -9,7 +9,7 @@
   {{productName}}
 </h1>
 <p id="description">
-  {{productDescription}}
+  {{ productDescription | striptags(true) | escape | nl2br }}
 </p>
 
 <form action="/pay/{{productExternalId}}" method="post" name="startPaymentForm" class="push-bottom">


### PR DESCRIPTION
Linebreaks were not showing as nunjucks strips them out by default, this
is good most of the time. So in this case we can use nunjucks filters to
show. If we convert the \n breaks to `<br>'s` and then escape we can see
them. Because escaping is dangerous we also strip out all tags so there
is nothing dodgy left to escape.