### PR TITLE
PP-3600 - remove beta tag and Pay from Header

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,7 +1,6 @@
 {% extends "../../govuk_modules/govuk_template/views/layouts/govuk_template.njk" %}
 
 {% set homepage_url = '/' %}
-{% set global_header_text = 'GOV.UK <span>Pay <strong class="phase-tag">Beta</strong></span>' | safe %}
 
 {% block page_title %}GOV.UK Pay{% endblock %}
 


### PR DESCRIPTION
On other user facing pages we don’t show “Pay” or the beta tag