### PR TITLE
BAU - fix broken logo link and remove links from footer

### DIFF
--- a/app/views/includes/footer-support-links.njk
+++ b/app/views/includes/footer-support-links.njk
@@ -1,6 +1,5 @@
 <nav class="footer-nav">
   <ul>
-    <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
-    <li><a href="https://www.payments.service.gov.uk/cookies/">Cookies</a></li>
+    <li><a href="https://www.payments.service.gov.uk/privacy">Privacy policy</a></li>
   </ul>
 </nav>

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -1,6 +1,6 @@
 {% extends "../../govuk_modules/govuk_template/views/layouts/govuk_template.njk" %}
 
-{% set homepage_url = '/' %}
+{% set homepage_url = 'https://www.gov.uk' %}
 
 {% block page_title %}GOV.UK Pay{% endblock %}
 
@@ -29,12 +29,8 @@
   </main>
 {% endblock %}
 
-{% block footer_top %}
-    {% include "includes/footer-categories.njk" %}
-{% endblock %}
-
 {% block footer_support_links %}
-    {% include "includes/footer-support-links.njk" %}
+  {% include "includes/footer-support-links.njk" %}
 {% endblock %}
 
 {% block body_end %}


### PR DESCRIPTION
The template was copied from the product page when it should match the
one on pay-frontend. This updates the links