### PR TITLE
PP-3726 Add extra page for reference input

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -8,7 +8,7 @@ const NUMBERS_ONLY = new RegExp('^[0-9]+$')
 const MAX_AMOUNT = 100000
 
 const validationErrors = {
-  required: 'This is field cannot be blank',
+  required: 'This field cannot be blank',
   currency: 'Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”',
   phoneNumber: 'Must be a 11 digit phone number',
   validEmail: 'Please use a valid email address',

--- a/app/controllers/pre_payment_controller.js
+++ b/app/controllers/pre_payment_controller.js
@@ -9,10 +9,11 @@ const errorResponse = response.renderErrorView
 
 const makePayment = require('./make_payment_controller')
 const adhocPaymentCtrl = require('./adhoc_payment')
+const productReferenceCtrl = require('./product_reference')
 
 // Constants
 const messages = {
-  internalError: 'We are unable to process your request at this time'
+  internalError: 'Sorry, we are unable to process your request'
 }
 
 module.exports = (req, res) => {
@@ -25,9 +26,13 @@ module.exports = (req, res) => {
     case ('PROTOTYPE'):
       return makePayment(req, res)
     case ('ADHOC'):
-      return adhocPaymentCtrl.index(req, res)
+      if (product.reference_enabled) {
+        return productReferenceCtrl.index(req, res)
+      } else {
+        return adhocPaymentCtrl.index(req, res)
+      }
+    default:
+      logger.error(`[${correlationId}] error routing product of type ${product.type}`)
+      return errorResponse(req, res, messages.internalError, 500)
   }
-
-  logger.error(`[${correlationId}] error routing product of type ${product.type}`)
-  return errorResponse(req, res, messages.internalError, 500)
 }

--- a/app/controllers/product_reference/get_product_reference_controller.js
+++ b/app/controllers/product_reference/get_product_reference_controller.js
@@ -1,0 +1,29 @@
+'use strict'
+
+// Node.js core dependencies
+const logger = require('winston')
+
+// Custom dependencies
+const response = require('../../utils/response').response
+
+module.exports = (req, res) => {
+  const product = req.product
+  const correlationId = req.correlationId
+  const data = {
+    productExternalId: product.externalId,
+    serviceName: product.serviceName,
+    productName: product.name,
+    productDescription: product.description,
+    productReferenceLabel: product.reference_label,
+    productReferenceHint: product.reference_hint
+  }
+
+  if (req.errorMessage) {
+    data.flash = {
+      genericError: req.errorMessage
+    }
+  }
+
+  logger.info(`[${correlationId}] initiating product payment for ${product.externalId}`)
+  response(req, res, 'reference/index', data)
+}

--- a/app/controllers/product_reference/index.js
+++ b/app/controllers/product_reference/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+module.exports.index = require('./get_product_reference_controller')
+module.exports.postReference = require('./post_product_reference_controller')

--- a/app/controllers/product_reference/post_product_reference_controller.js
+++ b/app/controllers/product_reference/post_product_reference_controller.js
@@ -14,7 +14,7 @@ module.exports = (req, res) => {
 
   const referenceNumber = req.body['payment-reference']
   if (!referenceNumber) {
-    req.errorMessage = `<h2>This is field cannot be blank</h2>`
+    req.errorMessage = `<h2>This field cannot be blank</h2>`
     return index(req, res)
   } else {
     client.payment.getByGatewayAccountIdAndReference(req.product.gatewayAccountId, referenceNumber)

--- a/app/controllers/product_reference/post_product_reference_controller.js
+++ b/app/controllers/product_reference/post_product_reference_controller.js
@@ -1,0 +1,34 @@
+'use strict'
+
+const index = require('./get_product_reference_controller')
+const client = require('../../services/clients/products_client')
+const adhocPaymentCtrl = require('../adhoc_payment')
+const {renderErrorView} = require('../../utils/response')
+
+module.exports = (req, res) => {
+  const product = req.product
+  if (product.referenceNumber) {
+    req.referenceNumber = product.referenceNumber
+    return adhocPaymentCtrl.index(req, res)
+  }
+
+  const referenceNumber = req.body['payment-reference']
+  if (!referenceNumber) {
+    req.errorMessage = `<h2>This is field cannot be blank</h2>`
+    return index(req, res)
+  } else {
+    client.payment.getByGatewayAccountIdAndReference(req.product.gatewayAccountId, referenceNumber)
+      .then(payment => {
+        req.errorMessage = `<h2>This reference has been used before</h2>`
+        return index(req, res)
+      })
+      .catch(err => {
+        if (err.errorCode === 404) {
+          req.referenceNumber = referenceNumber
+          return adhocPaymentCtrl.index(req, res)
+        } else {
+          renderErrorView(req, res, 'Sorry, we are unable to process your request', err.errorCode || 500)
+        }
+      })
+  }
+}

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -13,6 +13,9 @@ const lodash = require('lodash')
  * @property {string} description
  * @property {string} returnUrl
  * @property {string} serviceName - the name of the service with which the product is associated
+ * @property {Object} referenceEnabled - a flag that when enabled will ask for the payer to input a reference
+ * @property {Object} referenceLabel - a required field when reference is enabled
+ * @property {Object} referenceHint - a an optional field when reference is enabled
  * @property {object} links
  * @property {object} links.pay
  * @property {string} links.pay.href - url to use to create a payment for the product
@@ -31,6 +34,9 @@ class Product {
    * @param {string} opts.name - The name of the product
    * @param {number} opts.price - price of the product in pence
    * @param {string} opts.service_name - the name of the service with which the product is associated
+   * @param {string} opts.reference_enabled - when enabled will ask the user to input a reference for the payment
+   * @param {string} opts.reference_label - mandatory field that will display when reference is enabled
+   * @param {string} opts.reference_hint - optional field that will display when reference is enabled
    * @param {Object[]} opts._links - links for the product ('self' to re-GET this product from the server, and 'pay' to create a payment for this product)
    * @param {string} opts._links[].href - url of the link
    * @param {string} opts._links[].method - the http method of the link
@@ -48,6 +54,9 @@ class Product {
     this.serviceName = opts.service_name || 'Example Service Name'
     this.description = opts.description
     this.returnUrl = opts.return_url
+    this.reference_enabled = opts.reference_enabled
+    this.reference_label = opts.reference_label
+    this.reference_hint = opts.reference_hint
     opts._links.forEach(link => lodash.set(this, `links.${link.rel}`, {method: link.method, href: link.href}))
   }
 }

--- a/app/paths.js
+++ b/app/paths.js
@@ -11,7 +11,8 @@ module.exports = {
   },
   pay: {
     product: '/pay/:productExternalId',
-    complete: '/payment-complete/:paymentExternalId'
+    complete: '/payment-complete/:paymentExternalId',
+    reference: '/pay/reference/:productExternalId'
   },
   demoPayment: {
     success: '/successful',

--- a/app/routes.js
+++ b/app/routes.js
@@ -14,6 +14,7 @@ const completeCtrl = require('./controllers/payment_complete_controller')
 const failedCtrl = require('./controllers/demo_payment/payment_failed_controller')
 const successCtrl = require('./controllers/demo_payment/payment_success_controller')
 const adhocPaymentCtrl = require('./controllers/adhoc_payment')
+const productReferenceCtrl = require('./controllers/product_reference')
 
 // Middleware
 const {validateAndRefreshCsrf, ensureSessionHasCsrfSecret} = require('./middleware/csrf')
@@ -46,6 +47,10 @@ module.exports.bind = function (app) {
 
   // CREATE PAYMENT
   app.get(pay.product, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, prePaymentCtrl)
+
+  // CREATE REFERENCE
+  app.get(pay.reference, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, prePaymentCtrl)
+  app.post(pay.reference, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, productReferenceCtrl.postReference)
 
   // DEMO SPECIFIC SCREENS
   app.get(pay.complete, resolvePaymentAndProduct, completeCtrl)

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -1,0 +1,46 @@
+{% extends "../layout.njk" %}
+
+{% block page_title %}
+  {{ serviceName }}
+{% endblock %}
+
+{% block main_content %}
+  <h1 class="heading-large page-title">
+    Pay for {{ productName }}
+  </h1>
+  <p id="description">
+    {{ productDescription | striptags(true) | escape | nl2br }}
+  </p>
+
+  <form action="/pay/reference/{{ productExternalId }}" method="post" name="referencePaymentForm" class="push-bottom">
+    <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+    <div class="form-group">
+      <label id="product-reference-label" for="payment-reference" class="form-label-bold">
+        <span id="product-reference-label-span">{{ productReferenceLabel }}</span>
+        <span id="product-reference-label-hint" class="form-hint">{{ productReferenceHint }}</span>
+      </label>
+      {% if productReference %}
+        <div class="panel panel-border-wide">
+          <h2 id="payment-reference" class="lede">{{ paymentReference }}</h2>
+        </div>
+      {% else %}
+        <div>
+          <input class="form-control"
+                 aria-label=""
+                 name="payment-reference"
+                 data-non-numeric=""
+                 type="text"
+                 id="payment-reference"
+                 value=""
+                 autofocus=""
+                 data-validate="required field"
+                 data-confirmation="true"
+                 data-confirmation-label="Payment reference: "/>
+        </div>
+      {% endif %}
+    </div>
+    <button type="submit" class="button">
+      Continue
+    </button>
+  </form>
+{% endblock %}

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -81,6 +81,9 @@ module.exports = {
     if (data.type !== 'ADHOC') {
       data.price = data.price || randomPrice()
     }
+    if (opts.reference_enabled) data.reference_enabled = opts.reference_enabled
+    if (opts.reference_label) data.reference_label = opts.reference_label
+    if (opts.reference_hint) data.reference_hint = opts.reference_hint
     if (opts.description) data.description = opts.description
     if (opts.return_url) data.return_url = opts.return_url
     if (opts.service_name_path) data.service_name_path = opts.service_name_path
@@ -90,18 +93,27 @@ module.exports = {
         href: `http://products.url/v1/api/products/${data.external_id}`,
         rel: 'self',
         method: 'GET'
-      }, {
+      }]
+    }
+    if (data.reference_enabled) {
+      data._links.push({
+        href: `http://products-ui.url/pay/reference/${data.external_id}`,
+        rel: 'pay',
+        method: 'GET'
+      })
+    } else {
+      data._links.push({
         href: `http://products-ui.url/pay/${data.external_id}`,
         rel: 'pay',
         method: 'GET'
-      }]
-      if (opts.service_name_path && opts.product_name_path) {
-        data._links.push({
-          href: `http://products-ui.url/redirect/${opts.service_name_path}/${opts.product_name_path}`,
-          rel: 'friendly',
-          method: 'GET'
-        })
-      }
+      })
+    }
+    if (opts.service_name_path && opts.product_name_path) {
+      data._links.push({
+        href: `http://products-ui.url/redirect/${opts.service_name_path}/${opts.product_name_path}`,
+        rel: 'friendly',
+        method: 'GET'
+      })
     }
 
     return {

--- a/test/unit/controllers/payment_reference/get_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/get_product_reference_controller_test.js
@@ -1,0 +1,52 @@
+'use strict'
+const chai = require('chai')
+const config = require('../../../../config')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const supertest = require('supertest')
+const {getApp} = require('../../../../server')
+const {createAppWithSession} = require('../../../test_helpers/mock_session')
+const productFixtures = require('../../../fixtures/product_fixtures')
+const paths = require('../../../../app/paths')
+const expect = chai.expect
+let product, response, $
+
+describe('product reference index controller', function () {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('with reference enabled', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        product_name: 'Super duper product',
+        service_name: 'Super GOV service',
+        description: 'Super duper product description',
+        reference_enabled: true,
+        reference_label: 'Test reference label',
+        reference_hint: 'Test reference hint'
+      }).getPlain()
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+
+      supertest(createAppWithSession(getApp()))
+        .get(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code:200 OK', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should render product reference start page', () => {
+      expect($('title').text()).to.include(product.service_name)
+      expect($('h1.heading-large').text()).to.include(product.name)
+      expect($('p#description').text()).to.include(product.description)
+      expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
+    })
+  })
+})

--- a/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
@@ -122,7 +122,7 @@ describe('product reference post controller', function () {
       expect($('h1.heading-large').text()).to.include(product.name)
       expect($('p#description').text()).to.include(product.description)
       expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
-      expect($('.generic-error').text()).to.include('This is field cannot be blank')
+      expect($('.generic-error').text()).to.include('This field cannot be blank')
     })
   })
 

--- a/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
@@ -1,0 +1,162 @@
+'use strict'
+const chai = require('chai')
+const config = require('../../../../config')
+const cheerio = require('cheerio')
+const nock = require('nock')
+const csrf = require('csrf')
+const supertest = require('supertest')
+const {getApp} = require('../../../../server')
+const {createAppWithSession} = require('../../../test_helpers/mock_session')
+const productFixtures = require('../../../fixtures/product_fixtures')
+const paths = require('../../../../app/paths')
+const expect = chai.expect
+let payment, product, response, $
+
+describe('product reference post controller', function () {
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  describe('when reference is unique and can be used', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'Test reference label'
+      }).getPlain()
+      const newReference = 'I_AM_NEW'
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+      nock(config.PRODUCTS_URL).get(`/v1/api/payments/${product.gateway_account_id}/${newReference}`).reply(404)
+
+      supertest(createAppWithSession(getApp()))
+        .post(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .send({
+          'payment-reference': newReference,
+          csrfToken: csrf().create('123')
+        })
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code: 200 OK', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should navigate to adhoc payment start page after form submission', () => {
+      expect($('h1.heading-large').text()).to.include(product.name)
+      expect($('p#description').text()).to.include(product.description)
+      expect($('form').attr('action')).to.equal(`/pay/${product.external_id}`)
+    })
+  })
+
+  describe('when reference exists already', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'Test reference label',
+        reference_hint: 'Test reference hint'
+      }).getPlain()
+      const referenceNumber = 'I_EXIST'
+      payment = productFixtures.validCreatePaymentResponse({
+        reference_number: referenceNumber
+      }).getPlain()
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+      nock(config.PRODUCTS_URL).get(`/v1/api/payments/${product.gateway_account_id}/${referenceNumber}`).reply(200, payment)
+      supertest(createAppWithSession(getApp()))
+        .post(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .send({
+          'payment-reference': referenceNumber,
+          csrfToken: csrf().create('123')
+        })
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code: 200 OK', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should render product reference start page with error message', () => {
+      expect($('title').text()).to.include(product.service_name)
+      expect($('h1.heading-large').text()).to.include(product.name)
+      expect($('p#description').text()).to.include(product.description)
+      expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
+      expect($('.generic-error').text()).to.include('This reference has been used before')
+    })
+  })
+
+  describe('when missing reference field', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'Test reference label'
+      }).getPlain()
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+
+      supertest(createAppWithSession(getApp()))
+        .post(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .send({
+          csrfToken: csrf().create('123')
+        })
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code: 200 OK', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should render product reference start page with error message', () => {
+      expect($('title').text()).to.include(product.service_name)
+      expect($('h1.heading-large').text()).to.include(product.name)
+      expect($('p#description').text()).to.include(product.description)
+      expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
+      expect($('.generic-error').text()).to.include('This is field cannot be blank')
+    })
+  })
+
+  describe('when backend returns other then 404', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        reference_enabled: 'true',
+        reference_label: 'Test reference label'
+      }).getPlain()
+      const newReference = 'I_AM_NEW'
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+      nock(config.PRODUCTS_URL).get(`/v1/api/payments/${product.gateway_account_id}/${newReference}`).reply(418)
+
+      supertest(createAppWithSession(getApp()))
+        .post(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .send({
+          'payment-reference': newReference,
+          csrfToken: csrf().create('123')
+        })
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code: 418', () => {
+      expect(response.statusCode).to.equal(418)
+    })
+
+    it('should render adhoc payment start page', () => {
+      expect($('title').text()).to.include('An error occurred - GOV.UK Pay')
+      expect($('#errorMsg').text()).to.include('Sorry, we are unable to process your request')
+    })
+  })
+})


### PR DESCRIPTION
- Updated pre-payment controller to handle ADHOC payments with reference
enabled
- Added GET controller to handle rendering the page with the input field
- Added POST controller to handle form validation for the input field and
to forward to the payment amount page
- Added the new route to paths and exposed the http methods in the router
- Updated Product class to cater for the new properties: `reference_enabled`,
`reference_label` and `reference_hint`
- Added a new view that holds the form for the input field
- Updated tests and product fixtures to have the new properties