### PR TITLE
PP-3726 Wire up reference field

### DIFF
--- a/app/controllers/adhoc_payment/get_index_controller.js
+++ b/app/controllers/adhoc_payment/get_index_controller.js
@@ -5,7 +5,8 @@ const logger = require('winston')
 const currencyFormatter = require('currency-formatter')
 
 // Custom dependencies
-const response = require('../../utils/response').response
+const {response} = require('../../utils/response')
+const productReferenceCtrl = require('../product_reference')
 
 function asGBP (amountInPence) {
   return currencyFormatter.format((amountInPence / 100).toFixed(2), {code: 'GBP'})
@@ -20,6 +21,14 @@ module.exports = (req, res) => {
     productName: product.name,
     productDescription: product.description,
     productReferenceEnabled: product.reference_enabled
+  }
+  if (product.reference_enabled) {
+    const referenceNumber = req.referenceNumber
+    if (referenceNumber) {
+      data.referenceNumber = referenceNumber
+    } else {
+      productReferenceCtrl.index(req, res)
+    }
   }
 
   if (product.price) {

--- a/app/controllers/adhoc_payment/post_index_controller.js
+++ b/app/controllers/adhoc_payment/post_index_controller.js
@@ -5,11 +5,22 @@ const {isCurrency, isAboveMaxAmount} = require('../../browsered/field-validation
 
 const makePayment = require('../make_payment_controller')
 const index = require('./get_index_controller')
+const productReferenceCtrl = require('../product_reference')
 
 const AMOUNT_FORMAT = /^([0-9]+)(?:\.([0-9]{2}))?$/
 
 module.exports = (req, res) => {
   const product = req.product
+
+  if (product.reference_enabled) {
+    let referenceNumber = req.body['reference-number']
+    if (referenceNumber) {
+      req.referenceNumber = referenceNumber
+    } else {
+      productReferenceCtrl.index(req, res)
+    }
+  }
+
   if (product.price) {
     req.paymentAmount = product.price
     return makePayment(req, res)

--- a/app/controllers/make_payment_controller.js
+++ b/app/controllers/make_payment_controller.js
@@ -17,9 +17,10 @@ module.exports = (req, res) => {
   const product = req.product
   const correlationId = req.correlationId
   const paymentAmount = req.paymentAmount // should be undefined for non adhoc payments
+  const referenceNumber = req.referenceNumber // undefined for non ADHOC or ADHOC with reference disabled
   if (product) {
     logger.info(`[${correlationId}] creating charge for product ${product.name}`)
-    return productsClient.payment.create(product.externalId, paymentAmount)
+    return productsClient.payment.create(product.externalId, paymentAmount, referenceNumber)
       .then(payment => {
         logger.info(`[${correlationId}] initiating payment for charge ${payment.externalChargeId}`)
         return res.redirect(303, payment.links.next.href)

--- a/app/controllers/product_reference/get_product_reference_controller.js
+++ b/app/controllers/product_reference/get_product_reference_controller.js
@@ -16,6 +16,9 @@ module.exports = (req, res) => {
     productDescription: product.description,
     paymentReferenceLabel: product.reference_label
   }
+  if (req.referenceNumber) {
+    data.referenceNumber = req.referenceNumber
+  }
   if (product.reference_hint) {
     data.paymentReferenceHint = product.reference_hint
   }

--- a/app/services/clients/products_client.js
+++ b/app/services/clients/products_client.js
@@ -130,17 +130,19 @@ function deleteProduct (productExternalId) {
  * @param {int} price: The override price for the payment. If not present it will default to product price
  * @returns Promise<Payment>
  */
-function createPayment (productExternalId, price) {
+function createPayment (productExternalId, price, referenceNumber) {
   const createPaymentRequest = {
     baseUrl,
     url: `/products/${productExternalId}/payments`,
     description: 'create a payment for a product',
     service: SERVICE_NAME
   }
+  createPaymentRequest.body = {}
   if (price) {
-    createPaymentRequest.body = {
-      price: price
-    }
+    createPaymentRequest.body.price = price
+  }
+  if (referenceNumber) {
+    createPaymentRequest.body.reference_number = referenceNumber
   }
   return baseClient.post(createPaymentRequest)
     .then(payment => new Payment(payment))

--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -16,6 +16,9 @@
 
   <form action="/pay/{{ productExternalId }}" method="post" name="startPaymentForm" class="push-bottom">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+    {% if referenceNumber %}
+      <input id="reference-number" name="reference-number" type="hidden" value="{{ referenceNumber }}">
+    {% endif %}
     <div class="currency-input form-group">
       <label class="form-label-bold" for="payment-amount">
         Payment amount

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -21,6 +21,18 @@
           <span id="payment-reference-hint" class="form-hint">{{ paymentReferenceHint }}</span>
         {% endif %}
       </label>
+      {% if referenceNumber %}
+      <input class="form-control"
+             aria-label=""
+             name="payment-reference"
+             type="text"
+             id="payment-reference"
+             value="{{ referenceNumber }}"
+             autofocus=""
+             autocomplete="off"
+             maxlength="255"
+             data-validate="required field"/>
+      {% else %}
       <input class="form-control"
              aria-label=""
              name="payment-reference"
@@ -33,6 +45,7 @@
              data-validate="isNaxsiSafe"
              data-validate-max-lengt="255"/>
     </div>
+    {% endif %}
     <button type="submit" class="button">
       Continue
     </button>

--- a/test/unit/controllers/adhoc_payment/get_index_controller_unit_test.js
+++ b/test/unit/controllers/adhoc_payment/get_index_controller_unit_test.js
@@ -1,0 +1,46 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const {expect} = require('chai')
+
+const productFixtures = require('../../../fixtures/product_fixtures')
+const responseSpy = sinon.spy()
+const mockResponses = {
+  response: responseSpy
+}
+const adhocCtrl = proxyquire('../../../../app/controllers/adhoc_payment/get_index_controller', {
+  '../../utils/response': mockResponses
+})
+
+let req, res
+
+describe('get adhoc controller with reference enabled and reference set ', () => {
+  const product = productFixtures.validCreateProductResponse({
+    reference_enabled: true
+  }).getPlain()
+
+  before(() => {
+    res = {}
+    req = {
+      correlationId: '123',
+      referenceNumber: 'Test reference',
+      product
+    }
+    adhocCtrl(req, res)
+  })
+
+  it('should call method response', () => {
+    expect(responseSpy.called).to.equal(true)
+  })
+
+  it(`should pass req, res and 'adhoc-payment/index' to the response method`, () => {
+    expect(mockResponses.response.args[0]).to.include(req)
+    expect(mockResponses.response.args[0]).to.include(res)
+    expect(mockResponses.response.args[0]).to.include('adhoc-payment/index')
+  })
+
+  it(`should pass data to the responses.response method with a 'referenceNumber' property equal to 'Test reference'`, () => {
+    expect(mockResponses.response.args[0][3]).to.have.property('referenceNumber').to.equal('Test reference')
+  })
+})


### PR DESCRIPTION
- Added field payment_reference to the client call to `products`
- Updated views to pre-populate the reference when on reference page
and to have it hidden on the payment page
- Updated controllers to handle redirection when payment reference
required and not set