### PR TITLE
PP-3726 Handle edge cases for reference enabled

### DIFF
--- a/app/controllers/adhoc_payment/get_index_controller.js
+++ b/app/controllers/adhoc_payment/get_index_controller.js
@@ -7,6 +7,7 @@ const currencyFormatter = require('currency-formatter')
 // Custom dependencies
 const {response} = require('../../utils/response')
 const productReferenceCtrl = require('../product_reference')
+const {getSessionVariable} = require('../../utils/cookie')
 
 function asGBP (amountInPence) {
   return currencyFormatter.format((amountInPence / 100).toFixed(2), {code: 'GBP'})
@@ -23,11 +24,9 @@ module.exports = (req, res) => {
     productReferenceEnabled: product.reference_enabled
   }
   if (product.reference_enabled) {
-    const referenceNumber = req.referenceNumber
-    if (referenceNumber) {
-      data.referenceNumber = referenceNumber
-    } else {
-      productReferenceCtrl.index(req, res)
+    const sessionReferenceNumber = getSessionVariable(req, 'referenceNumber')
+    if (!sessionReferenceNumber) {
+      return productReferenceCtrl.index(req, res)
     }
   }
 

--- a/app/controllers/adhoc_payment/post_index_controller.js
+++ b/app/controllers/adhoc_payment/post_index_controller.js
@@ -6,6 +6,7 @@ const {isCurrency, isAboveMaxAmount} = require('../../browsered/field-validation
 const makePayment = require('../make_payment_controller')
 const index = require('./get_index_controller')
 const productReferenceCtrl = require('../product_reference')
+const {getSessionVariable} = require('../../utils/cookie')
 
 const AMOUNT_FORMAT = /^([0-9]+)(?:\.([0-9]{2}))?$/
 
@@ -13,9 +14,9 @@ module.exports = (req, res) => {
   const product = req.product
 
   if (product.reference_enabled) {
-    let referenceNumber = req.body['reference-number']
-    if (referenceNumber) {
-      req.referenceNumber = referenceNumber
+    const sessionReferenceNumber = getSessionVariable(req, 'referenceNumber')
+    if (sessionReferenceNumber) {
+      req.referenceNumber = sessionReferenceNumber
     } else {
       productReferenceCtrl.index(req, res)
     }

--- a/app/controllers/product_reference/get_product_reference_controller.js
+++ b/app/controllers/product_reference/get_product_reference_controller.js
@@ -5,6 +5,7 @@ const logger = require('winston')
 
 // Custom dependencies
 const response = require('../../utils/response').response
+const {getSessionVariable} = require('../../utils/cookie')
 
 module.exports = (req, res) => {
   const product = req.product
@@ -16,8 +17,9 @@ module.exports = (req, res) => {
     productDescription: product.description,
     paymentReferenceLabel: product.reference_label
   }
-  if (req.referenceNumber) {
-    data.referenceNumber = req.referenceNumber
+  const sessionReferenceNumber = getSessionVariable(req, 'referenceNumber')
+  if (sessionReferenceNumber) {
+    data.referenceNumber = sessionReferenceNumber
   }
   if (product.reference_hint) {
     data.paymentReferenceHint = product.reference_hint

--- a/app/controllers/product_reference/post_product_reference_controller.js
+++ b/app/controllers/product_reference/post_product_reference_controller.js
@@ -4,6 +4,7 @@ const index = require('./get_product_reference_controller')
 const client = require('../../services/clients/products_client')
 const adhocPaymentCtrl = require('../adhoc_payment')
 const {renderErrorView} = require('../../utils/response')
+const {setSessionVariable} = require('../../utils/cookie')
 
 module.exports = (req, res) => {
   const product = req.product
@@ -27,7 +28,7 @@ module.exports = (req, res) => {
       })
       .catch(err => {
         if (err.errorCode === 404) {
-          req.referenceNumber = referenceNumber
+          setSessionVariable(req, 'referenceNumber', referenceNumber)
           return adhocPaymentCtrl.index(req, res)
         } else {
           renderErrorView(req, res, 'Sorry, we are unable to process your request', err.errorCode || 500)

--- a/app/utils/cookie.js
+++ b/app/utils/cookie.js
@@ -6,10 +6,10 @@ const {COOKIE_MAX_AGE, SESSION_ENCRYPTION_KEY} = process.env
 const SESSION_COOKIE_NAME = 'session'
 
 function checkEnv () {
-  if (!isValidKey(SESSION_ENCRYPTION_KEY)) {
+  if (!isValidStringKey(SESSION_ENCRYPTION_KEY)) {
     throw new Error('cookie encryption key is not set')
   }
-  if (!isValidKey(COOKIE_MAX_AGE)) {
+  if (!isValidStringKey(COOKIE_MAX_AGE)) {
     throw new Error('cookie max age is not set')
   }
 }
@@ -20,7 +20,7 @@ function checkEnv () {
  * @param {string} key
  * @returns {boolean}
  */
-function isValidKey (key) {
+function isValidStringKey (key) {
   return !!key && typeof key === 'string'
 }
 
@@ -73,7 +73,7 @@ function getSessionVariable (req, key) {
  * @returns {string}
  */
 function getSessionCookieName () {
-  if (isValidKey(SESSION_ENCRYPTION_KEY)) {
+  if (isValidStringKey(SESSION_ENCRYPTION_KEY)) {
     return SESSION_COOKIE_NAME
   }
 }

--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -16,9 +16,6 @@
 
   <form action="/pay/{{ productExternalId }}" method="post" name="startPaymentForm" class="push-bottom">
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
-    {% if referenceNumber %}
-      <input id="reference-number" name="reference-number" type="hidden" value="{{ referenceNumber }}">
-    {% endif %}
     <div class="currency-input form-group">
       <label class="form-label-bold" for="payment-amount">
         Payment amount

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -31,7 +31,8 @@
              autofocus=""
              autocomplete="off"
              maxlength="255"
-             data-validate="required field"/>
+             data-validate="isNaxsiSafe"
+             data-validate-max-lengt="255"/>
       {% else %}
       <input class="form-control"
              aria-label=""
@@ -44,8 +45,8 @@
              maxlength="255"
              data-validate="isNaxsiSafe"
              data-validate-max-lengt="255"/>
+      {% endif %}
     </div>
-    {% endif %}
     <button type="submit" class="button">
       Continue
     </button>

--- a/test/test.env
+++ b/test/test.env
@@ -2,6 +2,7 @@ PRODUCTS_URL=http://localhost:8004
 SELFSERVICE_TRANSACTIONS_URL=http://localhost:8910/transactions
 SECURE_COOKIE_OFF=true
 COOKIE_MAX_AGE=10800000
+SESSION_COOKIE_NAME=session
 SESSION_ENCRYPTION_KEY=naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk
 SESSION_IN_MEMORY=true
 DISABLE_REQUEST_LOGGING=true

--- a/test/unit/client/product_client/payment/create_test.js
+++ b/test/unit/client/product_client/payment/create_test.js
@@ -47,7 +47,7 @@ describe('products client - creating a new payment', () => {
       response = productFixtures.validCreatePaymentResponse({product_external_id: productExternalId})
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCTS_RESOURCE}/${productExternalId}/payments`)
-          .withUponReceiving('a valid create charge create request 1')
+          .withUponReceiving('a valid create charge create request')
           .withMethod('POST')
           .withStatusCode(201)
           .withResponseBody(response.getPactified())

--- a/test/unit/controllers/payment_reference/get_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/get_product_reference_controller_test.js
@@ -86,4 +86,40 @@ describe('product reference index controller', function () {
       expect($('#payment-reference-hint').text()).to.equal('')
     })
   })
+
+  describe('with reference enabled and reference set in session', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        product_name: 'Super duper product',
+        service_name: 'Super GOV service',
+        description: 'Super duper product description',
+        reference_enabled: true,
+        reference_label: 'Test reference label'
+      }).getPlain()
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+
+      supertest(createAppWithSession(getApp(), {referenceNumber: 'Test reference'}))
+        .get(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code:200 OK', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should render product reference start page with reference pre-populated', () => {
+      expect($('title').text()).to.include(product.service_name)
+      expect($('h1.heading-large').text()).to.include(product.name)
+      expect($('p#description').text()).to.include(product.description)
+      expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
+      expect($('#payment-reference').attr('value')).to.equal('Test reference')
+      expect($('#payment-reference-label').text()).to.include('Test reference label')
+      expect($('#payment-reference-hint').text()).to.equal('')
+    })
+  })
 })

--- a/test/unit/utils/cookie_test.js
+++ b/test/unit/utils/cookie_test.js
@@ -11,8 +11,8 @@ const getCookiesUtil = sessionsStub => {
 }
 
 describe('cookie configuration', function () {
-  describe('when setting the config', function () {
-    it('should configure cookie correctly', function () {
+  describe('when setting the config correctly', function () {
+    it('should set session with expected values', function () {
       const clientSessionsStub = sinon.stub()
       const cookies = getCookiesUtil(clientSessionsStub)
 
@@ -32,6 +32,8 @@ describe('cookie configuration', function () {
 
       expect(clientSessionsStub.calledWith(expectedConfig)).to.equal(true)
     })
+  })
+  describe(`when missing SESSION_ENCRYPTION_KEY`, () => {
     it('should throw an error if no session key is set', function () {
       process.env.SESSION_ENCRYPTION_KEY = ''
 
@@ -40,8 +42,10 @@ describe('cookie configuration', function () {
 
       expect(() => cookies.sessionCookie()).to.throw(/cookie encryption key is not set/)
     })
+  })
+  describe(`when missing COOKIE_MAX_AGE`, () => {
     it('should throw an error if no max age is set', function () {
-      process.env.SESSION_ENCRYPTION_KEY = 'test encryption'
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
       process.env.COOKIE_MAX_AGE = ''
 
       const clientSessionsStub = sinon.stub()
@@ -53,7 +57,6 @@ describe('cookie configuration', function () {
 
   describe(`when setting value on cookie 'session'`, function () {
     it(`should set value on cookie 'session' if SESSION_ENCRYPTION_KEY set`, function () {
-      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
       const cookies = getCookiesUtil()
       const req = {
         session: {}
@@ -73,9 +76,8 @@ describe('cookie configuration', function () {
     })
   })
 
-  describe(`should get value from cookie 'session'`, function () {
-    it('only if SESSION_ENCRYPTION_KEY is set and cookie exists', function () {
-      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+  describe(`when SESSION_ENCRYPTION_KEY is set and cookie exists`, function () {
+    it(`should get value from cookie 'session'`, function () {
       const cookies = getCookiesUtil()
       const req = {
         session: {
@@ -87,9 +89,8 @@ describe('cookie configuration', function () {
     })
   })
 
-  describe(`should NOT get value from cookie 'session'`, function () {
-    it('when session key is NOT set', function () {
-      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+  describe(`when session key is NOT set`, function () {
+    it(`should NOT get value from cookie`, function () {
       const cookies = getCookiesUtil()
       const req = {
         session: {}
@@ -99,9 +100,8 @@ describe('cookie configuration', function () {
     })
   })
 
-  describe(`should NOT get value`, function () {
-    it('when cookie does NOT exist', function () {
-      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+  describe(`when cookie does NOT exist`, function () {
+    it('should NOT get value', function () {
       const cookies = getCookiesUtil()
       const req = {}
 

--- a/test/unit/utils/cookie_test.js
+++ b/test/unit/utils/cookie_test.js
@@ -1,0 +1,111 @@
+'use strict'
+
+// npm dependencies
+const {expect} = require('chai')
+const sinon = require('sinon')
+const proxyquire = require('proxyquire').noPreserveCache()
+
+const getCookiesUtil = sessionsStub => {
+  if (sessionsStub) return proxyquire('../../../app/utils/cookie', {'client-sessions': sessionsStub})
+  return proxyquire('../../../app/utils/cookie', {})
+}
+
+describe('cookie configuration', function () {
+  describe('when setting the config', function () {
+    it('should configure cookie correctly', function () {
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      const expectedConfig = {
+        cookieName: 'session',
+        secret: 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk',
+        duration: 10800000,
+        proxy: true,
+        cookie: {
+          ephemeral: false,
+          httpOnly: true,
+          secureProxy: true
+        }
+      }
+
+      cookies.sessionCookie()
+
+      expect(clientSessionsStub.calledWith(expectedConfig)).to.equal(true)
+    })
+    it('should throw an error if no session key is set', function () {
+      process.env.SESSION_ENCRYPTION_KEY = ''
+
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      expect(() => cookies.sessionCookie()).to.throw(/cookie encryption key is not set/)
+    })
+    it('should throw an error if no max age is set', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'test encryption'
+      process.env.COOKIE_MAX_AGE = ''
+
+      const clientSessionsStub = sinon.stub()
+      const cookies = getCookiesUtil(clientSessionsStub)
+
+      expect(() => cookies.sessionCookie()).to.throw(/cookie max age is not set/)
+    })
+  })
+
+  describe(`when setting value on cookie 'session'`, function () {
+    it(`should set value on cookie 'session' if SESSION_ENCRYPTION_KEY set`, function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      const cookies = getCookiesUtil()
+      const req = {
+        session: {}
+      }
+
+      cookies.setSessionVariable(req, 'testKey', 'testValue')
+
+      expect(req.session.testKey).to.equal('testValue')
+    })
+    it('does not set value on non-existent cookie', function () {
+      const cookies = getCookiesUtil()
+      const req = {}
+
+      cookies.setSessionVariable(req, 'testKey', 'testValue')
+
+      expect(req).to.deep.equal({})
+    })
+  })
+
+  describe(`should get value from cookie 'session'`, function () {
+    it('only if SESSION_ENCRYPTION_KEY is set and cookie exists', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      const cookies = getCookiesUtil()
+      const req = {
+        session: {
+          testKey: 'testValue'
+        }
+      }
+
+      expect(cookies.getSessionVariable(req, 'testKey')).to.equal('testValue')
+    })
+  })
+
+  describe(`should NOT get value from cookie 'session'`, function () {
+    it('when session key is NOT set', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      const cookies = getCookiesUtil()
+      const req = {
+        session: {}
+      }
+
+      expect(cookies.getSessionVariable(req, 'testKey')).to.equal(undefined)
+    })
+  })
+
+  describe(`should NOT get value`, function () {
+    it('when cookie does NOT exist', function () {
+      process.env.SESSION_ENCRYPTION_KEY = 'naskjwefvwei72rjkwfmjwfi72rfkjwefmjwefiuwefjkbwfiu24fmjbwfk'
+      const cookies = getCookiesUtil()
+      const req = {}
+
+      expect(cookies.getSessionVariable(req, 'testKey')).to.equal(undefined)
+    })
+  })
+})


### PR DESCRIPTION
- Moved reference value to the session such that is available to pre-populate
the input field when navigating back to the page, after adding a session
reference
- Removed reference hidden field from payment amount page because now
the value is in session
- Added extra methods to set/get values from session
- Added unit test for adhoc controller as this controller can be 3rd down
the line in the call chain and cannot be accessed from a direct route
- Modified adhoc controller to check for reference set in session, as opposed
to request or hidden field
- Updated test for client to create a payment with amount and reference
- Added unit tests for cookies
- Added naxsi validation on reference field if pre-populated
