### PR TITLE
Add environment variable flags

### DIFF
--- a/app/utils/cookie.js
+++ b/app/utils/cookie.js
@@ -4,6 +4,7 @@ const session = require('client-sessions')
 const _ = require('lodash')
 const {COOKIE_MAX_AGE, SESSION_ENCRYPTION_KEY} = process.env
 const SESSION_COOKIE_NAME = 'session'
+const DISABLE_INTERNAL_HTTPS = process.env.DISABLE_INTERNAL_HTTPS === 'true'
 
 function checkEnv () {
   if (!isValidStringKey(SESSION_ENCRYPTION_KEY)) {
@@ -34,7 +35,7 @@ function sessionCookie () {
     cookie: {
       ephemeral: false, // when true, cookie expires when the browser closes
       httpOnly: true, // when true, cookie is not accessible from javascript
-      secureProxy: true
+      secureProxy: !DISABLE_INTERNAL_HTTPS
     }
   })
 }

--- a/server.js
+++ b/server.js
@@ -2,7 +2,9 @@
 const path = require('path')
 
 // Please leave here even though it looks unused - this enables Node.js metrics to be pushed to Hosted Graphite
-require('./app/utils/metrics').metrics()
+if (!process.env.DISABLE_APPMETRICS) {
+  require('./app/utils/metrics.js').metrics()
+}
 
 // NPM dependencies
 const express = require('express')


### PR DESCRIPTION
Environment variable flags to permit setting of secure cookies on http and to omit appmetrics module. These are necessary changes in order to add products-ui to the pay local cli tool. Similar changes exist selfservice.

@tlwr 