### PR TITLE
Fix rounding error when converting input like 9.95 (£) to 995 (p)

### DIFF
--- a/app/controllers/adhoc_payment/post_index_controller.js
+++ b/app/controllers/adhoc_payment/post_index_controller.js
@@ -35,12 +35,12 @@ module.exports = (req, res) => {
     req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${isAboveMaxAmount(paymentAmount)}</h2>`
     return index(req, res)
   } else {
-    paymentAmount = paymentAmount.replace(/[^0-9.-]+/g, '')
+    paymentAmount = paymentAmount.replace(/[^0-9.]+/g, '')
     const currencyMatch = AMOUNT_FORMAT.exec(paymentAmount)
     if (!currencyMatch[2]) {
       paymentAmount = paymentAmount + '.00'
     }
-    req.paymentAmount = Math.trunc(paymentAmount * 100)
+    req.paymentAmount = Number(paymentAmount.replace('.', ''))
     makePayment(req, res)
   }
 }

--- a/test/unit/controllers/adhoc_payment/post_index_controller_test.js
+++ b/test/unit/controllers/adhoc_payment/post_index_controller_test.js
@@ -19,7 +19,7 @@ describe('adhoc payment submit-amount controller', function () {
 
   describe('variable amount ADHOC payment', function () {
     describe('when a valid amount is submitted', function () {
-      const priceOverride = 12550
+      const priceOverride = 995
       before(done => {
         product = productFixtures.validCreateProductResponse({
           type: 'ADHOC',
@@ -38,7 +38,7 @@ describe('adhoc payment submit-amount controller', function () {
         supertest(createAppWithSession(getApp()))
           .post(paths.pay.product.replace(':productExternalId', product.external_id))
           .send({
-            'payment-amount': '125.50',
+            'payment-amount': '9.95',
             csrfToken: csrf().create('123')
           })
           .end((err, res) => {


### PR DESCRIPTION
Without this fix, we convert £9.95 to 994p, which is just 😬