### PR TITLE
PP-4344: Update to our Alpine 3.8.1 w/nodejs 8.11.4 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM govukpay/nodejs:alpine-3.8
+FROM govukpay/nodejs:alpine-3.8.1
 
 RUN apk update &&\
     apk upgrade &&\


### PR DESCRIPTION
## WHAT
Update to Alpine Linux 3.8.1 and bring in Nodejs 8.11.4

## HOW 
CI will save us


