### PR TITLE
PP-4378: Use --no-cache with apk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM govukpay/nodejs:alpine-3.8.1
 
-RUN apk update &&\
-    apk upgrade &&\
-    apk add --update bash
+RUN apk --no-cache upgrade
+RUN apk add --no-cache bash
 
 ENV PORT 9000
 EXPOSE 9000


### PR DESCRIPTION
When building our images, using the --no-cache argument to Alpine's package
manager, apk, avoids saving package listings to disk. This reduces the size of
our docker images slightly.