### PR TITLE
PP-4181 - load GOV.UK Frontend scripts first

### DIFF
--- a/app/browsered.js
+++ b/app/browsered.js
@@ -7,6 +7,7 @@ const GOVUKFrontend = require('govuk-frontend')
 const fieldValidation = require('./browsered/field-validation')
 const inputConfim = require('./browsered/input-confirm')
 
+GOVUKFrontend.initAll()
+
 fieldValidation.enableFieldValidation()
 inputConfim()
-GOVUKFrontend.initAll()


### PR DESCRIPTION
These scripts are the most critical to load and they work in the widest
range of browsers. Having them first means that they should load fine
without being interupted by failures futher down the file