### PR TITLE
PP-4972 - remove unused ie8 boilerplate stuff

### DIFF
--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -1,4 +1,4 @@
-<link href="{{ css_path }}" media="screen" rel="stylesheet" type="text/css" />
+<link href="{{ css_path }}" media="all" rel="stylesheet" />
 
 {% if analyticsTrackingId %}
 <!-- Google Analytics -->

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -5,22 +5,7 @@
 {% endblock %}
 
 {% block head %}
-  <!--[if !IE 8]><!-->
-    <link href="/public/stylesheets/application.css" rel="stylesheet" />
-  <!--<![endif]-->
-
-  {# For Internet Explorer 8, you need to compile specific stylesheet #}
-  {# see https://github.com/alphagov/govuk-frontend/blob/master/docs/installation/supporting-internet-explorer-8.md #}
-  <!--[if IE 8]>
-    <link href="/govuk-frontend/all-ie8.css" rel="stylesheet" />
-  <![endif]-->
-
-  {# For older browsers to allow them to recognise HTML5 elements such as `<header>` #}
-  <!--[if lt IE 9]>
-    <script src="/html5-shiv/html5shiv.js"></script>
-  <![endif]-->
-
-{% include "includes/head.njk" %}
+  {% include "includes/head.njk" %}
 {% endblock %}
 
 {% block header %}


### PR DESCRIPTION
Noticed that our templates include IE8 boilerplate stuff that doesn’t work

We don’t technically support IE8 anyway, so rather than fix I will just remove all together.