### PR TITLE
PP-5015 throw error for missing translation

### DIFF
--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -20,8 +20,8 @@
     <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
     <div class="currency-input govuk-form-group">
       <label class="govuk-label govuk-!-font-weight-bold govuk-!-width-one-quarter" for="payment-amount">
-        {{ __('adhoc.paymentAmount') }}
-        <span class="govuk-visually-hidden">{{ __('adhoc.inCurrency') }}</span>
+        {{ __p('adhoc.paymentAmount') }}
+        <span class="govuk-visually-hidden">{{ __p('adhoc.inCurrency') }}</span>
       </label>
       {% if price %}
         {{ govukInsetText({
@@ -33,7 +33,7 @@
         <div class="currency-input__inner">
           <span class="currency-input__inner__unit">£</span>
           <input class="govuk-input govuk-!-width-one-quarter"
-                 aria-label="{{ __('adhoc.currencyInput.ariaLabel') }}"
+                 aria-label="{{ __p('adhoc.currencyInput.ariaLabel') }}"
                  name="payment-amount"
                  data-non-numeric=""
                  type="text"
@@ -42,13 +42,13 @@
                  autofocus=""
                  data-validate="required currency"
                  data-confirmation="true"
-                 data-confirmation-label="{{ __('adhoc.currencyInput.confirmationLabel') }} "
+                 data-confirmation-label="{{ __p('adhoc.currencyInput.confirmationLabel') }} "
                  data-confirmation-prepend="£"/>
         </div>
       {% endif %}
     </div>
     {{ govukButton({
-      text: __('buttons.proceed')
+      text: __p('buttons.proceed')
     }) }}
   </form>
 {% endblock %}

--- a/app/views/error.njk
+++ b/app/views/error.njk
@@ -1,9 +1,9 @@
 {% extends "layout.njk" %}
 
-{% block pageTitle %}{{ __('error.title') }} - GOV.UK Pay{% endblock %}
+{% block pageTitle %}{{ __p('error.title') }} - GOV.UK Pay{% endblock %}
 
 {% block contentBody %}
-  <h1 class="govuk-heading-l">{{ __('error.title') }}</h1>
+  <h1 class="govuk-heading-l">{{ __p('error.title') }}</h1>
 
   <div id="errorMsg" class="govuk-body">{{message}}</div>
 {% endblock %}

--- a/app/views/pay/confirmation.njk
+++ b/app/views/pay/confirmation.njk
@@ -1,7 +1,7 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-{{ __('confirmation.title') }} - {{serviceName}} - GOV.UK Pay
+{{ __p('confirmation.title') }} - {{serviceName}} - GOV.UK Pay
 {% endblock %}
 
 {% block contentBody %}
@@ -9,29 +9,29 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h2 class="govuk-panel__title">
-        {{ __('confirmation.title') }}
+        {{ __p('confirmation.title') }}
       </h2>
       <div class="govuk-panel__body">
-         {{ __('confirmation.referenceNumber') }} <br>
+         {{ __p('confirmation.referenceNumber') }} <br>
         <strong class="bold" id="payment-reference">{{ payment.reference }}</strong>
       </div>
     </div>
 
-    <h2 class="govuk-heading-m govuk-!-margin-top-6">{{ __('confirmation.next.title') }}</h2>
+    <h2 class="govuk-heading-m govuk-!-margin-top-6">{{ __p('confirmation.next.title') }}</h2>
     <p class="govuk-body">
-      {{ __('confirmation.next.body') }}
+      {{ __p('confirmation.next.body') }}
     </p>
 
-    <h2 class="govuk-heading-m">{{ __('confirmation.paymentSummary.title') }}</h2>
+    <h2 class="govuk-heading-m">{{ __p('confirmation.paymentSummary.title') }}</h2>
 
     <table class="govuk-table">
       <tbody class="govuk-table__body">
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell" scope="row">{{ __('confirmation.paymentSummary.description') }}</td>
+          <td class="govuk-table__cell" scope="row">{{ __p('confirmation.paymentSummary.description') }}</td>
           <td class="govuk-table__cell">{{serviceName}}</td>
         </tr>
         <tr class="govuk-table__row">
-          <td class="govuk-table__cell" scope="row">{{ __('confirmation.paymentSummary.amount') }}</td>
+          <td class="govuk-table__cell" scope="row">{{ __p('confirmation.paymentSummary.amount') }}</td>
           <td class="govuk-table__cell" id="payment-amount">{{payment.amount}}</td>
         </tr>
       </tbody>

--- a/app/views/pay/failed.njk
+++ b/app/views/pay/failed.njk
@@ -1,17 +1,17 @@
 {% extends "../layout.njk" %}
 
 {% block pageTitle %}
-{{ __('failed.title') }} - {{serviceName}} - GOV.UK Pay
+{{ __p('failed.title') }} - {{serviceName}} - GOV.UK Pay
 {% endblock %}
 
 {% block contentBody %}
-<h2 class="heading-medium">{{ __('failed.title') }}</h2>
+<h2 class="heading-medium">{{ __p('failed.title') }}</h2>
 <p>
-  {{ __('failed.body') }}
+  {{ __p('failed.body') }}
 </p>
 <p>
   <div id="restart-payment">
-    <a href="{{backToStartPage}}">{{ __('failed.tryAgain') }}</a>
+    <a href="{{backToStartPage}}">{{ __p('failed.tryAgain') }}</a>
   </div>
 </p>
 {% endblock %}

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -39,7 +39,7 @@
         }
       }) }}
       {{ govukButton({
-        text: __('buttons.continue')
+        text: __p('buttons.continue')
       }) }}
     </form>
   </div>

--- a/config/pay-translation.js
+++ b/config/pay-translation.js
@@ -1,0 +1,21 @@
+'use strict'
+// i18n’s built in translation function `__()` returns the key
+// if it can’t find a translation. This is problematic as we show
+// something gross like 'cardDetails.title' to the user.
+// So this is a custom function that will check that the string
+// doesn’t equal the key. And if it does throw an error so the
+// template fails to render but with a nice helpful error message.
+
+// NPM dependencies
+const i18n = require('i18n')
+
+module.exports = function payGetTranslation (req, res, next) {
+  res.locals.__p = function safelyTranslateKeys () {
+    const translation = i18n.__.apply(req, arguments)
+    if (arguments[0] === translation) {
+      throw new Error(`Template is missing a translation with ID: ${translation}`)
+    }
+    return translation
+  }
+  next()
+}

--- a/server.js
+++ b/server.js
@@ -19,6 +19,7 @@ const flash = require('connect-flash')
 const cookieParser = require('cookie-parser')
 const staticify = require('staticify')(path.join(__dirname, 'public'))
 const i18n = require('i18n')
+const i18nPayTranslation = require('./config/pay-translation')
 
 exports.staticify = staticify
 
@@ -112,6 +113,7 @@ function initialisePublic (app) {
 function initialisei18n (app) {
   i18n.configure(i18nConfig)
   app.use(i18n.init)
+  app.use(i18nPayTranslation)
 }
 
 function initialiseRoutes (app) {


### PR DESCRIPTION
Sister of this PR https://github.com/alphagov/pay-frontend/pull/752

i18n’s built in translation function __() returns the key
if it can’t find a translation. This is problematic as we show
something gross like 'cardDetails.title' to the user.
So this is a custom function that will check that the string
doesn’t equal the key. And if it does throw an error so the
template fails to render but with a nice helpful error message.

The error looks like this:
![image](https://user-images.githubusercontent.com/440503/55073408-95773200-5085-11e9-923b-5292bedf9055.png)

Which is how all the other Nunjucks errors look and it would mean you could never get your PR through tests