### PR TITLE
PP-5005 Fix existing pact tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lint": "./node_modules/.bin/standard --fix",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test-with-coverage": "node ./node_modules/nyc/bin/nyc npm test",
-    "test": "node ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests)'.js",
+    "test": "rm -rf ./pacts && ./node_modules/mocha/bin/mocha '!(node_modules)/**/*+(_test|_tests)'.js",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect"
   },

--- a/test/unit/client/adminusers_client/find_service_test.js
+++ b/test/unit/client/adminusers_client/find_service_test.js
@@ -35,7 +35,7 @@ describe('adminusers client - find a service associated with a particular gatewa
   let gatewayAccountId, response, result
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a service is found', () => {
     const customBranding = {

--- a/test/unit/client/product_client/payment/create_test.js
+++ b/test/unit/client/product_client/payment/create_test.js
@@ -38,7 +38,7 @@ describe('products client - creating a new payment', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a charge is successfully created', () => {
     before((done) => {

--- a/test/unit/client/product_client/payment/get_by_gateway_account_id_and_reference_test.js
+++ b/test/unit/client/product_client/payment/get_by_gateway_account_id_and_reference_test.js
@@ -35,7 +35,7 @@ describe('products client - find a payment by gateway account id and payment ref
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a payment is successfully found', () => {
     before((done) => {
@@ -44,7 +44,7 @@ describe('products client - find a payment by gateway account id and payment ref
       referenceNumber = 'REFERENCE1'
       response = productFixtures.validCreatePaymentResponse({ reference_number: referenceNumber })
       const interaction = new PactInteractionBuilder(`/v1/api/payments/${gatewayAccountId}/${referenceNumber}`)
-        .withUponReceiving('a valid get payment request')
+        .withUponReceiving('a valid get payment by gateway account id and reference request')
         .withMethod('GET')
         .withStatusCode(200)
         .withResponseBody(response.getPactified())

--- a/test/unit/client/product_client/payment/get_by_payment_external_id_test.js
+++ b/test/unit/client/product_client/payment/get_by_payment_external_id_test.js
@@ -38,7 +38,7 @@ describe('products client - find a payment by it\'s own external id', function (
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {
@@ -46,7 +46,7 @@ describe('products client - find a payment by it\'s own external id', function (
       paymentExternalId = 'existing-id'
       response = productFixtures.validCreatePaymentResponse({ external_id: paymentExternalId })
       const interaction = new PactInteractionBuilder(`${PAYMENT_RESOURCE}/${paymentExternalId}`)
-        .withUponReceiving('a valid get payment request')
+        .withUponReceiving('a valid get payment by external id request')
         .withMethod('GET')
         .withStatusCode(200)
         .withResponseBody(response.getPactified())
@@ -83,7 +83,7 @@ describe('products client - find a payment by it\'s own external id', function (
       paymentExternalId = 'non-existing-id'
       provider.addInteraction(
         new PactInteractionBuilder(`${PAYMENT_RESOURCE}/${paymentExternalId}`)
-          .withUponReceiving('a valid find product request with non existing id')
+          .withUponReceiving('a valid get payment by external id request with non existing id')
           .withMethod('GET')
           .withStatusCode(404)
           .build()

--- a/test/unit/client/product_client/payment/get_by_product_external_id_test.js
+++ b/test/unit/client/product_client/payment/get_by_product_external_id_test.js
@@ -39,7 +39,7 @@ describe('products client - find a payment by it\'s associated product external 
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {
@@ -51,7 +51,7 @@ describe('products client - find a payment by it\'s associated product external 
         productFixtures.validCreatePaymentResponse({ product_external_id: productExternalId })
       ]
       const interaction = new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/payments`)
-        .withUponReceiving('a valid get payment request')
+        .withUponReceiving('a valid get payments by product external id request')
         .withMethod('GET')
         .withStatusCode(200)
         .withResponseBody(response.map(item => item.getPactified()))

--- a/test/unit/client/product_client/product/create_test.js
+++ b/test/unit/client/product_client/product/create_test.js
@@ -38,7 +38,7 @@ describe('products client - create a new product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a product is successfully created', () => {
     before(done => {

--- a/test/unit/client/product_client/product/delete_test.js
+++ b/test/unit/client/product_client/product/delete_test.js
@@ -36,7 +36,7 @@ describe('products client - delete a product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a product is successfully deleted', () => {
     before(done => {

--- a/test/unit/client/product_client/product/disable_test.js
+++ b/test/unit/client/product_client/product/disable_test.js
@@ -36,7 +36,7 @@ describe('products client - disable a product', () => {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a product is successfully disabled', () => {
     before(done => {
@@ -62,13 +62,13 @@ describe('products client - disable a product', () => {
     })
   })
 
-  describe('create a product - bad request', () => {
+  describe('disable a product - bad request', () => {
     before(done => {
       const productsClient = getProductsClient()
-      productExternalId = 'a_non_existant_external_id'
+      productExternalId = 'a_non_existent_external_id'
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}/disable`)
-          .withUponReceiving('an invalid create product request')
+          .withUponReceiving('an invalid disable product request')
           .withMethod('PATCH')
           .withStatusCode(400)
           .build()

--- a/test/unit/client/product_client/product/get_by_gateway_account_id_test.js
+++ b/test/unit/client/product_client/product/get_by_gateway_account_id_test.js
@@ -38,7 +38,7 @@ describe('products client - find products associated with a particular gateway a
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when products are successfully found', () => {
     before(done => {

--- a/test/unit/client/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/client/product_client/product/get_by_product_external_id_test.js
@@ -38,7 +38,7 @@ describe('products client - find a product by it\'s external id', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {
@@ -53,7 +53,7 @@ describe('products client - find a product by it\'s external id', function () {
       })
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
-          .withUponReceiving('a valid get product request')
+          .withUponReceiving('a valid get product by external id request')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(response.getPactified())
@@ -91,7 +91,7 @@ describe('products client - find a product by it\'s external id', function () {
       productExternalId = 'non-existing-id'
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
-          .withUponReceiving('a valid find product request with non existing id')
+          .withUponReceiving('a valid find product by external id request with non existing id')
           .withMethod('GET')
           .withStatusCode(404)
           .build()

--- a/test/unit/client/product_client/product/get_by_product_path_test.js
+++ b/test/unit/client/product_client/product/get_by_product_path_test.js
@@ -40,7 +40,7 @@ describe('products client - find a product by it\'s product path', function () {
   })
 
   before(() => provider.setup())
-  after((done) => provider.finalize().then(done()))
+  after(() => provider.finalize())
 
   describe('when a product is successfully found', () => {
     before(done => {
@@ -61,7 +61,7 @@ describe('products client - find a product by it\'s product path', function () {
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
           .withQuery('serviceNamePath', serviceNamePath)
           .withQuery('productNamePath', productNamePath)
-          .withUponReceiving('a valid get product request')
+          .withUponReceiving('a valid get product by path request')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(response.getPactified())


### PR DESCRIPTION
Fix 'done' being called immediately in "after" step in pact tests and
instead return the Promise to ensure it is resolved.

Fix duplicate pact descriptions.