### PR TITLE
PP-5005 Enable products pact tests

### DIFF
--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -76,6 +76,7 @@ module.exports = {
       service_name: opts.service_name || 'An example service name',
       description: opts.description || '',
       price: opts.price,
+      language: opts.language || 'en',
       _links: opts.links
     }
     if (data.type !== 'ADHOC') {

--- a/test/fixtures/product_fixtures.js
+++ b/test/fixtures/product_fixtures.js
@@ -73,7 +73,6 @@ module.exports = {
       type: opts.type || 'DEMO',
       gateway_account_id: opts.gateway_account_id || randomGatewayAccountId(),
       name: opts.name || 'A Product Name',
-      service_name: opts.service_name || 'An example service name',
       description: opts.description || '',
       price: opts.price,
       language: opts.language || 'en',

--- a/test/unit/client/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/client/product_client/product/get_by_product_external_id_test.js
@@ -49,7 +49,8 @@ describe('products client - find a product by it\'s external id', function () {
         price: 1000,
         name: 'A Product Name',
         description: 'About this product',
-        return_url: 'https://example.gov.uk'
+        return_url: 'https://example.gov.uk',
+        language: 'en'
       })
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
@@ -74,6 +75,7 @@ describe('products client - find a product by it\'s external id', function () {
       expect(result.description).to.exist.and.equal(plainResponse.description)
       expect(result.price).to.exist.and.equal(plainResponse.price)
       expect(result.returnUrl).to.exist.and.equal(plainResponse.return_url)
+      expect(result.language).to.exist.and.equal(plainResponse.language)
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(2)
       expect(result.links).to.have.property('self')

--- a/test/unit/client/product_client/product/get_by_product_external_id_test.js
+++ b/test/unit/client/product_client/product/get_by_product_external_id_test.js
@@ -28,7 +28,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`, productsApiKey
 
 describe('products client - find a product by it\'s external id', function () {
   const provider = Pact({
-    consumer: 'products-ui-to-be',
+    consumer: 'products-ui',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -55,6 +55,7 @@ describe('products client - find a product by it\'s external id', function () {
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}/${productExternalId}`)
           .withUponReceiving('a valid get product by external id request')
+          .withState('a product with external id existing-id exists')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(response.getPactified())
@@ -96,6 +97,7 @@ describe('products client - find a product by it\'s external id', function () {
           .withUponReceiving('a valid find product by external id request with non existing id')
           .withMethod('GET')
           .withStatusCode(404)
+          .withResponseHeaders({})
           .build()
       )
         .then(() => productsClient.product.getByProductExternalId(productExternalId), done)

--- a/test/unit/client/product_client/product/get_by_product_path_test.js
+++ b/test/unit/client/product_client/product/get_by_product_path_test.js
@@ -30,7 +30,7 @@ function getProductsClient (baseUrl = `http://localhost:${port}`) {
 
 describe('products client - find a product by it\'s product path', function () {
   const provider = Pact({
-    consumer: 'products-ui-to-be',
+    consumer: 'products-ui',
     provider: 'products',
     port: port,
     log: path.resolve(process.cwd(), 'logs', 'mockserver-integration.log'),
@@ -63,6 +63,7 @@ describe('products client - find a product by it\'s product path', function () {
           .withQuery('serviceNamePath', serviceNamePath)
           .withQuery('productNamePath', productNamePath)
           .withUponReceiving('a valid get product by path request')
+          .withState('a product with path service-name-path/product-name-path exists')
           .withMethod('GET')
           .withStatusCode(200)
           .withResponseBody(response.getPactified())
@@ -110,6 +111,7 @@ describe('products client - find a product by it\'s product path', function () {
           .withUponReceiving('a valid find product request with non existing product path')
           .withMethod('GET')
           .withStatusCode(404)
+          .withResponseHeaders({})
           .build()
       )
         .then(() => productsClient.product.getByProductPath(serviceNamePath, productNamePath), done)

--- a/test/unit/client/product_client/product/get_by_product_path_test.js
+++ b/test/unit/client/product_client/product/get_by_product_path_test.js
@@ -55,7 +55,8 @@ describe('products client - find a product by it\'s product path', function () {
         description: 'About this product',
         return_url: 'https://example.gov.uk',
         service_name_path: serviceNamePath,
-        product_name_path: productNamePath
+        product_name_path: productNamePath,
+        language: 'en'
       })
       provider.addInteraction(
         new PactInteractionBuilder(`${PRODUCT_RESOURCE}`)
@@ -82,6 +83,7 @@ describe('products client - find a product by it\'s product path', function () {
       expect(result.description).to.exist.and.equal(plainResponse.description)
       expect(result.price).to.exist.and.equal(plainResponse.price)
       expect(result.returnUrl).to.exist.and.equal(plainResponse.return_url)
+      expect(result.language).to.exist.and.equal(plainResponse.language)
       expect(result).to.have.property('links')
       expect(Object.keys(result.links).length).to.equal(3)
       expect(result.links).to.have.property('self')


### PR DESCRIPTION
- Modify pacts to expect the new 'language' field.
- Change consumer of pact tests for products endpoints to 'products-ui' so they will be run.
- Add provider states to tests that require them.
- Modify Pact tests to get them working against the provider.
- Remove a Pact test which was wrong and unnecessary to test products by gateway account when there are no products.