### PR TITLE
PP-5006 - make errors translatable

### DIFF
--- a/app/controllers/friendly_url_redirect_controller.js
+++ b/app/controllers/friendly_url_redirect_controller.js
@@ -6,12 +6,10 @@ const logger = require('winston')
 // Custom dependencies
 const productsClient = require('../services/clients/products_client')
 const response = require('../utils/response')
-const errorResponse = response.renderErrorView
+const { renderErrorView } = response
 
 // Constants
-const messages = {
-  internalError: 'We are unable to process your request at this time'
-}
+const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
 
 module.exports = (req, res) => {
   const { serviceNamePath, productNamePath } = req.params
@@ -21,6 +19,6 @@ module.exports = (req, res) => {
       return res.redirect(product.links.pay.href)
     })
     .catch(err => {
-      return errorResponse(req, res, messages.internalError, err.errorCode || 500)
+      return renderErrorView(req, res, errorMessagePath, err.errorCode || 500)
     })
 }

--- a/app/controllers/make_payment_controller.js
+++ b/app/controllers/make_payment_controller.js
@@ -5,13 +5,11 @@ const logger = require('winston')
 
 // Custom dependencies
 const response = require('../utils/response')
-const errorResponse = response.renderErrorView
+const { renderErrorView } = response
 const productsClient = require('../services/clients/products_client')
 
 // Constants
-const messages = {
-  internalError: 'We are unable to process your request at this time'
-}
+const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
 
 module.exports = (req, res) => {
   const product = req.product
@@ -27,10 +25,10 @@ module.exports = (req, res) => {
       })
       .catch(err => {
         logger.error(`[${correlationId}] error creating charge for product ${product.externalId}. err = ${err}`)
-        return errorResponse(req, res, messages.internalError, err.errorCode || 500)
+        return renderErrorView(req, res, errorMessagePath, err.errorCode || 500)
       })
   } else {
     logger.error(`[${correlationId}] product not found to make payment`)
-    return errorResponse(req, res, messages.internalError, 500)
+    return renderErrorView(req, res, errorMessagePath, 500)
   }
 }

--- a/app/controllers/payment_complete_controller.js
+++ b/app/controllers/payment_complete_controller.js
@@ -5,15 +5,14 @@ const logger = require('winston')
 
 // Custom dependencies
 const response = require('../utils/response')
-const errorResponse = response.renderErrorView
+const { renderErrorView } = response
 
 // Local dependencies
 const { demoPayment, pay } = require('../paths')
 const paymentStatus = require('./payment_status_controller')
+
 // Constants
-const messages = {
-  internalError: 'We are unable to process your request at this time'
-}
+const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
 
 module.exports = (req, res) => {
   const payment = req.payment
@@ -32,6 +31,6 @@ module.exports = (req, res) => {
       break
     default:
       logger.error(`[${correlationId}] error routing payment complete based on product type ${product.type}`)
-      return errorResponse(req, res, messages.internalError, 500)
+      return renderErrorView(req, res, errorMessagePath, 500)
   }
 }

--- a/app/controllers/pre_payment_controller.js
+++ b/app/controllers/pre_payment_controller.js
@@ -5,16 +5,14 @@ const logger = require('winston')
 
 // Custom dependencies
 const response = require('../utils/response')
-const errorResponse = response.renderErrorView
+const { renderErrorView } = response
 
 const makePayment = require('./make_payment_controller')
 const adhocPaymentCtrl = require('./adhoc_payment')
 const productReferenceCtrl = require('./product_reference')
 
 // Constants
-const messages = {
-  internalError: 'Sorry, we are unable to process your request'
-}
+const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
 
 module.exports = (req, res) => {
   const product = req.product
@@ -33,6 +31,6 @@ module.exports = (req, res) => {
       }
     default:
       logger.error(`[${correlationId}] error routing product of type ${product.type}`)
-      return errorResponse(req, res, messages.internalError, 500)
+      return renderErrorView(req, res, errorMessagePath, 500)
   }
 }

--- a/app/middleware/csrf.js
+++ b/app/middleware/csrf.js
@@ -5,11 +5,11 @@ const csrf = require('csrf')
 const logger = require('winston')
 
 // Local Dependencies
-const errorView = require('../utils/response.js').renderErrorView
+const { renderErrorView } = require('../utils/response.js')
 const CORRELATION_HEADER = require('../../config').CORRELATION_HEADER
 
 // Assignments and Variables
-const errorMsg = 'There is a problem with the payments platform'
+const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
 
 // Exports
 module.exports = {
@@ -22,17 +22,17 @@ function validateAndRefreshCsrf (req, res, next) {
   const session = req.session
   if (!session) {
     logger.warn('Session is not defined')
-    return errorView(req, res, errorMsg, 400)
+    return renderErrorView(req, res, errorMessagePath, 400)
   }
 
   if (!session.csrfSecret) {
     logger.warn('CSRF secret is not defined for session')
-    return errorView(req, res, errorMsg, 400)
+    return renderErrorView(req, res, errorMessagePath, 400)
   }
 
   if (req.method !== 'GET' && !isValidCsrf(req)) {
     logger.warn('CSRF secret provided is invalid')
-    return errorView(req, res, errorMsg, 400)
+    return renderErrorView(req, res, errorMessagePath, 400)
   }
 
   res.locals.csrf = csrf().create(session.csrfSecret)

--- a/app/middleware/resolve_payment_and_product.js
+++ b/app/middleware/resolve_payment_and_product.js
@@ -26,6 +26,6 @@ module.exports = function (req, res, next) {
       next()
     })
     .catch(err => {
-      renderErrorView(req, res, 'Sorry, we are unable to process your request', err.errorCode || 500)
+      renderErrorView(req, res, 'error.internal', err.errorCode || 500)
     })
 }

--- a/app/middleware/resolve_product.js
+++ b/app/middleware/resolve_product.js
@@ -22,6 +22,6 @@ module.exports = function (req, res, next) {
       next()
     })
     .catch(err => {
-      renderErrorView(req, res, 'Sorry, we are unable to process your request', err.errorCode || 500)
+      renderErrorView(req, res, 'error.internal', err.errorCode || 500)
     })
 }

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -2,7 +2,7 @@
 
 const logger = require('winston')
 
-const ERROR_MESSAGE = 'There is a problem with the payments platform'
+const ERROR_MESSAGE = 'error.default' // This is the object notation to string in en.json
 const ERROR_VIEW = 'error'
 
 function response (req, res, template, data) {

--- a/app/views/error.njk
+++ b/app/views/error.njk
@@ -5,5 +5,5 @@
 {% block contentBody %}
   <h1 class="govuk-heading-l">{{ __p('error.title') }}</h1>
 
-  <div id="errorMsg" class="govuk-body">{{message}}</div>
+  <div id="errorMsg" class="govuk-body">{{ __p(message) }}</div>
 {% endblock %}

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -1,10 +1,10 @@
 {
   "adhoc": {
     "paymentAmount": "Swm y taliad",
-    "inCurrency": "in £",
+    "inCurrency": "mewn £",
     "currencyInput": {
-      "ariaLabel": "Enter amount in pounds",
-      "confirmationLabel": "Amount to pay:"
+      "ariaLabel": "Nodwch y cyfanswm mewn punnoedd",
+      "confirmationLabel": "Cyfanswm i’w dalu:"
     }
   },
   "buttons": {
@@ -12,17 +12,19 @@
     "continue": "Parhau"
   },
   "error": {
-    "title": "Digwyddodd gwall:"
+    "title": "Digwyddodd gwall:",
+    "default": "Mae’n ddrwg gennym, ond ni allwn brosesu eich cais. Rhowch gynnig arall arni wedyn.",
+    "internal": "Mae problem gyda’r cyfleuster taliadau. Rhowch gynnig arall arni wedyn"
   },
   "confirmation": {
     "title": "Roedd eich taliad yn llwyddiannus",
     "referenceNumber": "Rhif cyfeirnod eich taliad yw",
     "next": {
-      "title": "Beth sy'n digwydd nesaf",
+      "title": "Beth sy’n digwydd nesaf",
       "body": "Rydym wedi anfon e-bost atoch yn cadarnhau eich bod wedi gwneud taliad."
     },
     "paymentSummary": {
-      "title": "Crynodeb o'r taliad",
+      "title": "Crynodeb o’r taliad",
       "description": "Taliad am:",
       "amount": "Cyfanswm:"
     }

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,7 +12,9 @@
     "continue": "Continue"
   },
   "error": {
-    "title": "An error occurred:"
+    "title": "An error occurred:",
+    "default": "There’s a problem with the payments platform. Please try again later",
+    "internal": "Sorry, we’re unable to process your request. Try again later."
   },
   "confirmation": {
     "title": "Your payment was successful",

--- a/test/unit/controllers/friendly_url_redirect_controller_test.js
+++ b/test/unit/controllers/friendly_url_redirect_controller_test.js
@@ -69,7 +69,7 @@ describe('friendly url redirect controller', function () {
     })
     it('should render error page', () => {
       expect($('.govuk-heading-l').text()).to.equal('An error occurred:')
-      expect($('#errorMsg').text()).to.equal('We are unable to process your request at this time')
+      expect($('#errorMsg').text()).to.equal('Sorry, we’re unable to process your request. Try again later.')
     })
   })
 })

--- a/test/unit/controllers/payment_complete_controller_test.js
+++ b/test/unit/controllers/payment_complete_controller_test.js
@@ -245,7 +245,7 @@ describe('payment complete controller', () => {
     })
     it('should render error page', () => {
       expect($('.govuk-heading-l').text()).to.equal('An error occurred:')
-      expect($('#errorMsg').text()).to.equal('Sorry, we are unable to process your request')
+      expect($('#errorMsg').text()).to.equal('Sorry, we’re unable to process your request. Try again later.')
     })
   })
 })

--- a/test/unit/controllers/pre_payment_controller_test.js
+++ b/test/unit/controllers/pre_payment_controller_test.js
@@ -65,7 +65,7 @@ describe('pre payment controller', function () {
         })
         it('should render error page', () => {
           expect($('.govuk-heading-l').text()).to.equal('An error occurred:')
-          expect($('#errorMsg').text()).to.equal('We are unable to process your request at this time')
+          expect($('#errorMsg').text()).to.equal('Sorry, we’re unable to process your request. Try again later.')
         })
       })
       describe('and the product is not resolved', () => {
@@ -85,7 +85,7 @@ describe('pre payment controller', function () {
         })
         it('should render error page', () => {
           expect($('.govuk-heading-l').text()).to.equal('An error occurred:')
-          expect($('#errorMsg').text()).to.equal('Sorry, we are unable to process your request')
+          expect($('#errorMsg').text()).to.equal('Sorry, we’re unable to process your request. Try again later.')
         })
       })
     })
@@ -163,7 +163,7 @@ describe('pre payment controller', function () {
     })
     it('should render error page', () => {
       expect($('.govuk-heading-l').text()).to.equal('An error occurred:')
-      expect($('#errorMsg').text()).to.equal('Sorry, we are unable to process your request')
+      expect($('#errorMsg').text()).to.equal('Sorry, we’re unable to process your request. Try again later.')
     })
   })
 })

--- a/test/unit/middleware/resolve_payment_and_product_test.js
+++ b/test/unit/middleware/resolve_payment_and_product_test.js
@@ -79,7 +79,7 @@ describe('resolve payment middleware', () => {
 
     it(`should render the error view`, () => {
       expect(res.render.lastCall.args[0]).to.equal('error')
-      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('Sorry, we are unable to process your request')
+      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('error.internal')
     })
 
     it(`it should not call 'next'`, () => {
@@ -115,7 +115,7 @@ describe('resolve payment middleware', () => {
 
     it(`should render the error view`, () => {
       expect(res.render.lastCall.args[0]).to.equal('error')
-      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('Sorry, we are unable to process your request')
+      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('error.internal')
     })
 
     it(`it should not call 'next'`, () => {
@@ -149,7 +149,7 @@ describe('resolve payment middleware', () => {
 
     it(`should render the error view`, () => {
       expect(res.render.lastCall.args[0]).to.equal('error')
-      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('Sorry, we are unable to process your request')
+      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('error.internal')
     })
 
     it(`it should not call 'next'`, () => {

--- a/test/unit/middleware/resolve_product_test.js
+++ b/test/unit/middleware/resolve_product_test.js
@@ -75,7 +75,7 @@ describe('resolve product middleware', () => {
 
     it(`should render the error view`, () => {
       expect(res.render.lastCall.args[0]).to.equal('error')
-      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('Sorry, we are unable to process your request')
+      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('error.internal')
     })
 
     it(`it should not call 'next'`, () => {
@@ -110,7 +110,7 @@ describe('resolve product middleware', () => {
 
     it(`should render the error view`, () => {
       expect(res.render.lastCall.args[0]).to.equal('error')
-      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('Sorry, we are unable to process your request')
+      expect(res.render.lastCall.args[1]).to.have.property('message').to.equal('error.internal')
     })
 
     it(`it should not call 'next'`, () => {


### PR DESCRIPTION
PP-5006 - Move error messages to strings file
> Also add missing Welsh translations and make all apostrophes proper

PP-5006 - Remove all error message strings
> And replace with path to string in locales/*.json
> Also use object destructuring for requires

PP-5006 - Update tests with new strings
