### PR TITLE
PP-4986 Internationalise reference server validation

### DIFF
--- a/app/controllers/adhoc_payment/post_index_controller.js
+++ b/app/controllers/adhoc_payment/post_index_controller.js
@@ -1,23 +1,15 @@
 'use strict'
 
-// NPM dependencies
-const i18n = require('i18n')
-
-// Custom dependencies
 const { isCurrency, isAboveMaxAmount } = require('../../browsered/field-validation-checks')
 
 const makePayment = require('../make_payment_controller')
 const index = require('./get_index_controller')
 const productReferenceCtrl = require('../product_reference')
 const { getSessionVariable } = require('../../utils/cookie')
-const i18nConfig = require('../../../config/i18n')
 
 const AMOUNT_FORMAT = /^([0-9]+)(?:\.([0-9]{2}))?$/
 
-i18n.configure(i18nConfig)
-
 module.exports = (req, res) => {
-  i18n.setLocale(req.product.language || 'en')
   const product = req.product
 
   if (product.reference_enabled) {
@@ -35,19 +27,22 @@ module.exports = (req, res) => {
   }
 
   let paymentAmount = req.body['payment-amount']
-  if (!paymentAmount || isCurrency(paymentAmount, i18n.__('fieldValidation.currency'))) {
-    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${isCurrency(paymentAmount, i18n.__('fieldValidation.currency'))}</h2>`
+  const currencyError = isCurrency(paymentAmount, res.locals.__p('fieldValidation.currency'))
+  if (currencyError) {
+    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${currencyError}</h2>`
     return index(req, res)
-  } else if (isAboveMaxAmount(paymentAmount, i18n.__('fieldValidation.isAboveMaxAmount'))) {
-    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${isAboveMaxAmount(paymentAmount, i18n.__('fieldValidation.isAboveMaxAmount'))}</h2>`
-    return index(req, res)
-  } else {
-    paymentAmount = paymentAmount.replace(/[^0-9.]+/g, '')
-    const currencyMatch = AMOUNT_FORMAT.exec(paymentAmount)
-    if (!currencyMatch[2]) {
-      paymentAmount = paymentAmount + '.00'
-    }
-    req.paymentAmount = Number(paymentAmount.replace('.', ''))
-    makePayment(req, res)
   }
+  const maxAmountError = isAboveMaxAmount(paymentAmount, res.locals.__p('fieldValidation.isAboveMaxAmount'))
+  if (maxAmountError) {
+    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${maxAmountError}</h2>`
+    return index(req, res)
+  }
+
+  paymentAmount = paymentAmount.replace(/[^0-9.]+/g, '')
+  const currencyMatch = AMOUNT_FORMAT.exec(paymentAmount)
+  if (!currencyMatch[2]) {
+    paymentAmount = paymentAmount + '.00'
+  }
+  req.paymentAmount = Number(paymentAmount.replace('.', ''))
+  makePayment(req, res)
 }

--- a/app/controllers/product_reference/post_product_reference_controller.js
+++ b/app/controllers/product_reference/post_product_reference_controller.js
@@ -3,6 +3,7 @@
 const index = require('./get_product_reference_controller')
 const adhocPaymentCtrl = require('../adhoc_payment')
 const { setSessionVariable } = require('../../utils/cookie')
+const { isNaxsiSafe } = require('../../browsered/field-validation-checks')
 
 module.exports = (req, res) => {
   const product = req.product
@@ -13,10 +14,16 @@ module.exports = (req, res) => {
 
   const referenceNumber = req.body['payment-reference']
   if (!referenceNumber) {
-    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">Enter a ${product.reference_label}</h2>`
+    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${res.locals.__p('fieldValidation.generic').replace('%s', product.reference_label)}</h2>`
     return index(req, res)
-  } else if (referenceNumber.trim().length > 255) {
-    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">The ${product.reference_label} is not valid</h2>`
+  }
+  if (referenceNumber.trim().length > 255) {
+    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${res.locals.__p('fieldValidation.isGreaterThanMaxLengthChars')}</h2>`
+    return index(req, res)
+  }
+  const invalidCharactersError = isNaxsiSafe(referenceNumber, res.locals.__p('fieldValidation.invalidCharacters'))
+  if (invalidCharactersError) {
+    req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${invalidCharactersError}</h2>`
     return index(req, res)
   }
   setSessionVariable(req, 'referenceNumber', referenceNumber)

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -36,6 +36,7 @@
   },
   "fieldValidation": {
     "summary": "Mae’r meysydd canlynol yn wag neu yn cynnwys camgymeriadau",
+    "generic": "Rhowch %s dilys",
     "required": "Ni all y maes hwn fod yn wag",
     "currency": "Dewiswch swm mewn punnoedd a cheiniogau drwy ddefnyddio digidau a phwynt degol. Er enghraifft “10.50”",
     "phoneNumber": "Must be a 11 digit phone number",
@@ -43,6 +44,6 @@
     "isHttps": "URL must begin with https://",
     "isAboveMaxAmount": "Dewiswch swm sy'n llai na £%s",
     "isGreaterThanMaxLengthChars": "Mae'r testun yn rhy hir. Ni all fod yn fwy na 255 o nodau.",
-    "invalidCharacters": "Ni allwch ddefnyddio unrhyw rai o'r nodau canlynol < > ; : ` ( ) \" ' = | \",\" ~ [ ]"
+    "invalidCharacters": "Ni allwch ddefnyddio unrhyw rai o'r nodau canlynol < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -36,6 +36,7 @@
   },
   "fieldValidation": {
     "summary": "The following fields are missing or contain errors",
+    "generic": "Enter a valid %s",
     "required": "This field can’t be blank",
     "currency": "Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”",
     "phoneNumber": "Must be a 11 digit phone number",
@@ -43,6 +44,6 @@
     "isHttps": "URL must begin with https://",
     "isAboveMaxAmount": "Choose an amount under £%s",
     "isGreaterThanMaxLengthChars": "Text is too long. It can be no more than 255 characters.",
-    "invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]"
+    "invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
   }
 }

--- a/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
@@ -90,7 +90,7 @@ describe('product reference post controller', function () {
       expect($('h1').text()).to.include(product.name)
       expect($('p#description').text()).to.include(product.description)
       expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
-      expect($('.govuk-heading-m').text()).to.include(`Enter a Test reference label`)
+      expect($('.govuk-heading-m').text()).to.include(`Enter a valid Test reference label`)
     })
   })
 
@@ -128,7 +128,45 @@ describe('product reference post controller', function () {
       expect($('h1').text()).to.include(product.name)
       expect($('p#description').text()).to.include(product.description)
       expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
-      expect($('.govuk-heading-m').text()).to.include(`The Test reference label is not valid`)
+      expect($('.govuk-heading-m').text()).to.include('Text is too long')
+    })
+  })
+
+  describe('when reference field contains disallowed characters', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'Test reference label'
+      }).getPlain()
+      service = serviceFixtures.validServiceResponse().getPlain()
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+      nock(config.ADMINUSERS_URL).get(`/v1/api/services?gatewayAccountId=${product.gateway_account_id}`).reply(200, service)
+
+      const referenceNumber = '<>'
+      supertest(createAppWithSession(getApp()))
+        .post(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .send({
+          'payment-reference': referenceNumber,
+          csrfToken: csrf().create('123')
+        })
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code: 200 OK', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should render product reference start page with error message', () => {
+      expect($('title').text()).to.include(service.service_name.en)
+      expect($('h1').text()).to.include(product.name)
+      expect($('p#description').text()).to.include(product.description)
+      expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
+      expect($('.govuk-heading-m').text()).to.include(`You can’t use any of the following characters`)
     })
   })
 })


### PR DESCRIPTION
- Internationalise server-side errors for the reference page.
- Add server-side check for disallowed characters.
- Use the res.locals.__p in controllers rather than initialising i18n each time.