### PR TITLE
PP-5314 - Clear stored reference when passing user to frontend

### DIFF
--- a/app/controllers/adhoc_payment/post_index_controller.js
+++ b/app/controllers/adhoc_payment/post_index_controller.js
@@ -5,7 +5,7 @@ const { isCurrency, isAboveMaxAmount } = require('../../browsered/field-validati
 const makePayment = require('../make_payment_controller')
 const index = require('./get_index_controller')
 const productReferenceCtrl = require('../product_reference')
-const { getSessionVariable } = require('../../utils/cookie')
+const { getSessionVariable, setSessionVariable } = require('../../utils/cookie')
 
 const AMOUNT_FORMAT = /^([0-9]+)(?:\.([0-9]{2}))?$/
 
@@ -44,5 +44,6 @@ module.exports = (req, res) => {
     paymentAmount = paymentAmount + '.00'
   }
   req.paymentAmount = Number(paymentAmount.replace('.', ''))
+  setSessionVariable(req, 'referenceNumber', '')
   makePayment(req, res)
 }


### PR DESCRIPTION
We were storing in a cookie the value users enter in the reference
field for as long as the cookie persists. This means if you made a
payment link payment and then came back a few days later to do it again
it would show you the reference from the last time, people find the
disconcerting and it’s probably not very useful.

So now when the user is passed from product-ui to frontend the stored
reference is cleared.