### PR TITLE
PP-5366 - use inputmode on numeric fields

### DIFF
--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -40,9 +40,10 @@
                  name="payment-amount"
                  data-non-numeric=""
                  type="text"
+                 inputmode="numeric"
                  id="payment-amount"
                  value=""
-                 autofocus=""
+                 autofocus
                  data-validate="required currency"
                  data-confirmation="true"
                  data-confirmation-label="{{ __p('adhoc.currencyInput.confirmationLabel') }} "


### PR DESCRIPTION
The Design System team have done some accessibility testing on `input
type="number"` and deemed them problematic. They have suggested using

`input type="text" inputmode="numeric" pattern="[0-9]*"`

instead as documented here https://github.com/alphagov/govuk-frontend/issues/1449

But because this is a currency input and we need to accept decimals points we’re going with 

`input type="text" inputmode="numeric"` in this case