### PR TITLE
PP-5574 - Add more informative page titles

### DIFF
--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 
 {% block pageTitle %}
-  {{ serviceName }}
+  {{ __p('adhoc.currencyInput.ariaLabel') }} - {{ productName }} - {{ serviceName }}
 {% endblock %}
 
 {% block contentBody %}

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block pageTitle %}
-  {{ serviceName }}
+  {{ paymentReferenceLabel }} - {{ productName }} - {{ serviceName }}
 {% endblock %}
 
 {% block contentBody %}


### PR DESCRIPTION
Before the titles were just the service name. Now they follow the
following pattern

What the page does - Product name - Service name