### PR TITLE
PP-5670: Specify consumer when running provider test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
           env.PACT_TAG = gitBranchName()
         }
         ws('contract-tests-wp') {
-          runPactProviderTests("pay-products", "${env.PACT_TAG}")
+          runPactProviderTests("pay-products", "${env.PACT_TAG}", "products-ui")
           runPactProviderTests("pay-adminusers", "${env.PACT_TAG}")
         }
       }


### PR DESCRIPTION
This will cause only the products-ui->connector test to run on a products-ui
build during the connector provider test run.