### PR TITLE
PP-5809 Don't log request failures at error level

### DIFF
--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   logRequestFailure: (context, response) => {
-    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
+    logger.info(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
       service: context.service,
       method: context.method,
       url: context.url,


### PR DESCRIPTION
Requests to other apps returning failure codes does not necessarily
mean an error, so don't log at error level.