### PR TITLE
PP-5809 Remove trailing dashes in log lines

### DIFF
--- a/app/middleware/error_handler.js
+++ b/app/middleware/error_handler.js
@@ -21,7 +21,7 @@ module.exports = function (err, req, res, next) {
   }
 
   // log the exception
-  logger.error(`[requestId=${req.correlationId}] Internal server error -`, errorPayload)
+  logger.error(`[requestId=${req.correlationId}] Internal server error`, errorPayload)
   // re-throw it
   next(err)
 }

--- a/app/utils/request_logger.js
+++ b/app/utils/request_logger.js
@@ -2,7 +2,7 @@ const logger = require('./logger')(__filename)
 
 module.exports = {
   logRequestStart: context => {
-    logger.debug(`Calling ${context.service}  ${context.description}-`, {
+    logger.debug(`Calling ${context.service}  ${context.description}`, {
       service: context.service,
       method: context.method,
       url: context.url
@@ -15,7 +15,7 @@ module.exports = {
   },
 
   logRequestFailure: (context, response) => {
-    logger.info(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed -`, {
+    logger.info(`[${context.correlationId}] Calling ${context.service} to ${context.description} failed`, {
       service: context.service,
       method: context.method,
       url: context.url,
@@ -24,7 +24,7 @@ module.exports = {
   },
 
   logRequestError: (context, error) => {
-    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception -`, {
+    logger.error(`[${context.correlationId}] Calling ${context.service} to ${context.description} threw exception`, {
       service: context.service,
       method: context.method,
       url: context.url,

--- a/app/utils/response.js
+++ b/app/utils/response.js
@@ -10,7 +10,7 @@ function response (req, res, template, data) {
 }
 
 function errorResponse (req, res, msg = ERROR_MESSAGE, status = 500) {
-  logger.error(`[${req.correlationId}] ${status} An error has occurred. Rendering error view -`, { errorMessage: msg })
+  logger.error(`[${req.correlationId}] ${status} An error has occurred. Rendering error view`, { errorMessage: msg })
   res.setHeader('Content-Type', 'text/html')
   res.status(status)
   res.render(ERROR_VIEW, { message: msg })


### PR DESCRIPTION
These dashes were there previously because before we logged in JSON the
logger would concatenate the JSON object it was passed as a second
parameter into the line.

Now, however, the keys in this JSON object are merged into the top-level
JSON object for the logline, so there is a hanging dash on the end of
the message which makes it appear that the message is incomplete. Remove
these.