### PR TITLE
PP-5918 Remove reference from landing page (PII)

### DIFF
--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 
 {% block pageTitle %}
-  {{ paymentReferenceLabel }} - {{ productName }} - {{ serviceName }}
+  {{ __p('adhoc.title') }} {{ serviceName }}
 {% endblock %}
 
 {% block contentBody %}


### PR DESCRIPTION
Follows up on https://github.com/alphagov/pay-products-ui/pull/583, reference is also in the landing page title. 

* Make this title the same as "entering amount page"