### PR TITLE
BAU Revert Sentry Version Bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   },
   "dependencies": {
     "@govuk-pay/pay-js-commons": "2.19.1",
-    "@sentry/node": "5.10.2",
+    "@sentry/node": "5.9.0",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",
     "body-parser": "1.19.x",


### PR DESCRIPTION
- Reverts the version of Sentry we use to see if this fixes errors