### PR TITLE
PP-5977 Disable google analytics

### DIFF
--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -6,26 +6,33 @@
 
 {% if analyticsTrackingId %}
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  {# The below code is commented out so we don't store Google Analytic cookies for ICO compliance.
+    We create a empty ga() function so not to throw a ReferenceError
+    Uncomment when we enable opt-in for cookies and remove the ga() function. #}
+
+  function ga() {
+  }
+
+  {# (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga'); #}
 
   {# GOV.UK Pay google analytics #}
-  ga('create', '{{ analyticsTrackingId }}', 'auto');
+  {# ga('create', '{{ analyticsTrackingId }}', 'auto');
   ga('set', 'anonymizeIp', true);
   ga('set', 'displayFeaturesTask', null);
   ga('set', 'transport', 'beacon');
   ga('send', 'pageview', {
     'page': '{{ analytics.path }}',
     'dimension1': '{{serviceName}}'
-  });
+  }); #}
 
   {# X-Gov google analtyics #}
-  ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
+  {# ga('create', 'UA-145652997-1', 'auto', 'govuk_shared', {'allowLinker': true});
   ga('govuk_shared.require', 'linker');
   ga('govuk_shared.linker.set', 'anonymizeIp', true);
   ga('govuk_shared.linker:autoLink', ['www.gov.uk']);
-  ga('govuk_shared.send', 'pageview');
+  ga('govuk_shared.send', 'pageview'); #}
 </script>
 {% endif %}


### PR DESCRIPTION
Complying with ICO guidance around cookie consent we can't set
non-essential cookies without consent being granted. In the short term
then we have to disable Google Analytics as it stores cookies.