### PR TITLE
PP-6047: Set a few cookies on the products page

### DIFF
--- a/app/controllers/adhoc_payment/get_index_controller.js
+++ b/app/controllers/adhoc_payment/get_index_controller.js
@@ -40,8 +40,8 @@ module.exports = (req, res) => {
 
   logger.info('Setting test cookie, strict cookie and lax cookie')
   res.cookie('DefaulCookie', 'cookie-to-test-Chrome-default-behavior', {})
-  res.cookie('LaxCookie', 'cookie-set-with-SameSite-Lax', { sameSite: 'lax' })
-  res.cookie('StrictCookie', 'cookie-set-with-SameSite-Strict-', { sameSite: 'strict' })
+  res.cookie('LaxCookie', 'cookie-set-with-SameSite-Lax', { sameSite: 'lax', domain: 'products.pymnt.uk' })
+  res.cookie('StrictCookie', 'cookie-set-with-SameSite-Strict-', { sameSite: 'strict', domain: 'products.pymnt.uk' })
   logger.info(`[${correlationId}] initiating product payment for ${product.externalId}`)
   response(req, res, 'adhoc-payment/index', data)
 }

--- a/app/controllers/adhoc_payment/get_index_controller.js
+++ b/app/controllers/adhoc_payment/get_index_controller.js
@@ -39,9 +39,9 @@ module.exports = (req, res) => {
   }
 
   logger.info('Setting test cookie, strict cookie and lax cookie')
-  res.cookie('Test Cookie', 'cookie-to-test-Chrome-default-behavior', {})
-  res.cookie('Lax Cookie', 'cookie-set-with-SameSite-Lax', { sameSite: 'lax' })
-  res.cookie('Strict Cookie', 'cookie-set-with-SameSite-Strict-', { sameSite: 'strict' })
+  res.cookie('DefaulCookie', 'cookie-to-test-Chrome-default-behavior', {})
+  res.cookie('LaxCookie', 'cookie-set-with-SameSite-Lax', { sameSite: 'lax' })
+  res.cookie('StrictCookie', 'cookie-set-with-SameSite-Strict-', { sameSite: 'strict' })
   logger.info(`[${correlationId}] initiating product payment for ${product.externalId}`)
   response(req, res, 'adhoc-payment/index', data)
 }

--- a/app/controllers/adhoc_payment/get_index_controller.js
+++ b/app/controllers/adhoc_payment/get_index_controller.js
@@ -39,9 +39,9 @@ module.exports = (req, res) => {
   }
 
   logger.info('Setting test cookie, strict cookie and lax cookie')
-  res.cookie('Test Cookie', 'A cookie to test Chrome default behavior', {})
-  res.cookie('Lax Cookie', 'This cookie was set with SameSite "Lax"', { sameSite: 'lax' })
-  res.cookie('Strict Cookie', 'This cookie was set with SameSite "Strict"', { sameSite: 'strict' })
+  res.cookie('Test Cookie', 'cookie-to-test-Chrome-default-behavior', {})
+  res.cookie('Lax Cookie', 'cookie-set-with-SameSite-Lax', { sameSite: 'lax' })
+  res.cookie('Strict Cookie', 'cookie-set-with-SameSite-Strict-', { sameSite: 'strict' })
   logger.info(`[${correlationId}] initiating product payment for ${product.externalId}`)
   response(req, res, 'adhoc-payment/index', data)
 }

--- a/app/controllers/adhoc_payment/get_index_controller.js
+++ b/app/controllers/adhoc_payment/get_index_controller.js
@@ -38,6 +38,10 @@ module.exports = (req, res) => {
     }
   }
 
+  logger.info('Setting test cookie, strict cookie and lax cookie')
+  res.cookie('Test Cookie', 'A cookie to test Chrome default behavior', {})
+  res.cookie('Lax Cookie', 'This cookie was set with SameSite "Lax"', { sameSite: 'lax' })
+  res.cookie('Strict Cookie', 'This cookie was set with SameSite "Strict"', { sameSite: 'strict' })
   logger.info(`[${correlationId}] initiating product payment for ${product.externalId}`)
   response(req, res, 'adhoc-payment/index', data)
 }

--- a/test/unit/controllers/adhoc_payment/get_index_controller_unit_test.js
+++ b/test/unit/controllers/adhoc_payment/get_index_controller_unit_test.js
@@ -35,7 +35,7 @@ describe('get adhoc controller with reference enabled', () => {
   const service = new Service(serviceFixtures.validServiceResponse().getPlain())
   describe(`when reference set `, () => {
     before(() => {
-      res = {}
+      res = { cookie: () => {} }
       req = {
         correlationId: '123',
         product,


### PR DESCRIPTION
Come Chrome 80 (set for release 4th Feb 2020), chrome will treat cookies as
SameSite=Lax by default. (Current default is None.) We need to see if this
change causes cookies set by services to still be present when the user clicks
confirm and the browser redirects the user back to the service's page.

This commit sets a few cookies to test which ones get sent to across sites. This is only
meant to be temporary. Unfortunately this can't be tested locally using `pay
local` as all the hosts are "localhost"!