### PR TITLE
PP-6029: Add PaaS manifest

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,8 @@
+memory: 500M
+disk_quota: 500M
+analytics_tracking_id: testing-123
+disable_appmetrics: true
+disable_internal_https: true
+disable_request_logging: true
+metrics_host: localhost
+session_encryption_key: asdjhbwefbo23r23rbfik2roiwhefwbqw

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,27 @@
+---
+applications:
+  - name: products-ui
+    buildpacks:
+      - nodejs_buildpack
+    health-check-type: http
+    health-check-http-endpoint: '/healthcheck'
+    health-check-invocation-timeout: 5
+    memory: ((memory))
+    disk_quota: ((disk_quota))
+    command: npm start
+    env:
+      ADMINUSERS_URL: ((adminusers_url))
+      ANALYTICS_TRACKING_ID: ((analytics_tracking_id))
+      COOKIE_MAX_AGE: '5400000'
+      CORRELATION_HEADER_NAME: x-request-id
+      DISABLE_APPMETRICS: ((disable_appmetrics))
+      DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
+      DISABLE_REQUEST_LOGGING: ((disable_request_logging))
+      METRICS_HOST: ((metrics_host))
+      NODE_ENV: production
+      NODE_WORKER_COUNT: '1'
+      PRODUCTS_URL: ((products_url))
+      SELFSERVICE_TRANSACTIONS_URL: ((selfservice_transactions_url))
+      SESSION_ENCRYPTION_KEY: ((session_encryption_key))
+    routes:
+      - route: ((products_ui_route))

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "MIT",
   "engines": {
-    "node": "12.2.0"
+    "node": "12.11.1"
   },
   "standard": {
     "globals": [


### PR DESCRIPTION
I've added a `manifest.yml` and `dev.yml` for pushing the app to PaaS.
The app can be pushed as follows:

```
cf push --vars-file dev.yml \
  --var adminusers_url=https://adminusers.example.com \
  --var products_url=https://products.example.com \
  --var selfservice_transactions_url=https://selfservice.example.com \
  --var products_ui_route=pay-products-ui-test.cloudapps.digital
```

The `public/.keep` has been added because Express complains about
a missing `public` directory if it doesn't exist and the PaaS app fails
to start.