### PR TITLE
PP-6085 Add env-map buildpack

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -1,0 +1,4 @@
+env_vars:
+  ADMINUSERS_URL: '."user-provided"[0].credentials.adminusers_url'
+  PRODUCTS_URL: '."user-provided"[0].credentials.products_url'
+  SELFSERVICE_TRANSACTIONS_URL: '."user-provided"[0].credentials.selfservice_transactions_url'

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,15 +2,17 @@
 applications:
   - name: products-ui
     buildpacks:
+      - https://github.com/alphagov/env-map-buildpack.git#v1
       - nodejs_buildpack
     health-check-type: http
     health-check-http-endpoint: '/healthcheck'
     health-check-invocation-timeout: 5
     memory: ((memory))
     disk_quota: ((disk_quota))
+    services:
+      - app-catalog
     command: npm start
     env:
-      ADMINUSERS_URL: ((adminusers_url))
       ANALYTICS_TRACKING_ID: ((analytics_tracking_id))
       COOKIE_MAX_AGE: '5400000'
       CORRELATION_HEADER_NAME: x-request-id
@@ -20,8 +22,9 @@ applications:
       METRICS_HOST: ((metrics_host))
       NODE_ENV: production
       NODE_WORKER_COUNT: '1'
-      PRODUCTS_URL: ((products_url))
-      SELFSERVICE_TRANSACTIONS_URL: ((selfservice_transactions_url))
       SESSION_ENCRYPTION_KEY: ((session_encryption_key))
-    routes:
-      - route: ((products_ui_route))
+
+      # These are taken via bound service, see `env-map.yml`
+      ADMINUSERS_URL: ""
+      PRODUCTS_URL: ""
+      SELFSERVICE_TRANSACTIONS_URL: ""


### PR DESCRIPTION
Add a build pack that extracts values from within VCAP_SERVICES which is
where the credentials from bound services will be provided to the app
running on PaaS. Using this buildpack means we do not need to alter how
our app works, but rather provide a mapping from the VCAP_SERVICES var to its
current name.

## WHAT
Tested that the env var are correctly set. `selfservice_transactions_url` is null becaues the .tf update hasn't been run yet see https://github.com/alphagov/pay-omnibus/pull/70/files

```
GDS5062 > cf ssh products-ui -c "/tmp/lifecycle/shell /home/vcap/app 'env | sort'" | grep URL
ADMINUSERS_URL=http://adminusers-stg.apps.internal:8080
PRODUCTS_URL=http://products-stg.apps.internal:8080
SELFSERVICE_TRANSACTIONS_URL=null
```