### PR TITLE
PP-6127 Add secret service for PaaS

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -1,4 +1,7 @@
 env_vars:
-  ADMINUSERS_URL: '."user-provided"[0].credentials.adminusers_url'
-  PRODUCTS_URL: '."user-provided"[0].credentials.products_url'
-  SELFSERVICE_TRANSACTIONS_URL: '."user-provided"[0].credentials.selfservice_transactions_url'
+  ADMINUSERS_URL:               '.[][] | select(.name == "app-catalog") | .credentials.adminusers_url'
+  PRODUCTS_URL:                 '.[][] | select(.name == "app-catalog") | .credentials.products_url'
+  SELFSERVICE_TRANSACTIONS_URL: '.[][] | select(.name == "app-catalog") | .credentials.selfservice_transactions_url'
+  SENTRY_DSN:                   '.[][] | select(.name == "products-ui-secret-service") | .credentials.sentry_dsn'
+  SESSION_ENCRYPTION_KEY:       '.[][] | select(.name == "products-ui-secret-service") | .credentials.session_encryption_key'
+  ANALYTICS_TRACKING_ID:        '.[][] | select(.name == "products-ui-secret-service") | .credentials.analytics_tracking_id'

--- a/manifest.yml
+++ b/manifest.yml
@@ -11,9 +11,9 @@ applications:
     disk_quota: ((disk_quota))
     services:
       - app-catalog
+      - products-ui-secret-service
     command: npm start
     env:
-      ANALYTICS_TRACKING_ID: ((analytics_tracking_id))
       COOKIE_MAX_AGE: '5400000'
       CORRELATION_HEADER_NAME: x-request-id
       DISABLE_APPMETRICS: ((disable_appmetrics))
@@ -22,9 +22,13 @@ applications:
       METRICS_HOST: ((metrics_host))
       NODE_ENV: production
       NODE_WORKER_COUNT: '1'
-      SESSION_ENCRYPTION_KEY: ((session_encryption_key))
 
       # These are taken via bound service, see `env-map.yml`
       ADMINUSERS_URL: ""
       PRODUCTS_URL: ""
       SELFSERVICE_TRANSACTIONS_URL: ""
+
+      # These are provided by products-ui-secret-service, see `env-map.yml`
+      SESSION_ENCRYPTION_KEY: ""
+      ANALYTICS_TRACKING_ID: ""
+      SENTRY_DSN: ""


### PR DESCRIPTION
Env vars which are specific to products-ui and differ by environment
are to be provided via the products-ui-secret-service. The mapping
between these vars and their keys within the vars returned by
products-ui-secret-service are defined within env-map.yml.

## WHAT

Tested by manually pushing to staging after adding the secret-service. App runs and vars are present.
