### PR TITLE
PP-5984 Fix validation parity on user entered reference

### DIFF
--- a/app/controllers/product_reference/post_product_reference_controller.js
+++ b/app/controllers/product_reference/post_product_reference_controller.js
@@ -17,7 +17,7 @@ module.exports = (req, res) => {
     req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${res.locals.__p('fieldValidation.generic').replace('%s', product.reference_label)}</h2>`
     return index(req, res)
   }
-  if (referenceNumber.trim().length > 255) {
+  if (referenceNumber.trim().length > 50) {
     req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${res.locals.__p('fieldValidation.isGreaterThanMaxLengthChars')}</h2>`
     return index(req, res)
   }

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -33,9 +33,7 @@
         value: referenceNumber,
         attributes: {
           autofocus: "",
-          maxlength: "255",
-          "data-validate": "isNaxsiSafe",
-          "data-validate-max-length": "255"
+          "data-validate": "isNaxsiSafe"
         }
       }) }}
       {{ govukButton({

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -41,7 +41,7 @@
     "required": "Ni all y maes hwn fod yn wag",
     "currency": "Dewiswch swm mewn punnoedd a cheiniogau drwy ddefnyddio digidau a phwynt degol. Er enghraifft “10.50”",
     "isAboveMaxAmount": "Dewiswch swm sy'n llai na £%s",
-    "isGreaterThanMaxLengthChars": "Mae'r testun yn rhy hir. Ni all fod yn fwy na 255 o nodau.",
+    "isGreaterThanMaxLengthChars": "Mae'r testun yn rhy hir. Ni all fod yn fwy na 50 o nodau.",
     "invalidCharacters": "Ni allwch ddefnyddio unrhyw rai o'r nodau canlynol < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -41,7 +41,7 @@
     "required": "This field can’t be blank",
     "currency": "Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”",
     "isAboveMaxAmount": "Choose an amount under £%s",
-    "isGreaterThanMaxLengthChars": "Text is too long. It can be no more than 255 characters.",
+    "isGreaterThanMaxLengthChars": "Text is too long. It can be no more than 50 characters.",
     "invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
   }
 }

--- a/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
@@ -94,7 +94,7 @@ describe('product reference post controller', function () {
     })
   })
 
-  describe('when reference field exceeds max length 255', function () {
+  describe('when reference field exceeds max length', function () {
     before(done => {
       product = productFixtures.validCreateProductResponse({
         type: 'ADHOC',

--- a/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
@@ -90,7 +90,7 @@ describe('product reference post controller', function () {
       expect($('h1').text()).to.include(product.name)
       expect($('p#description').text()).to.include(product.description)
       expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
-      expect($('.govuk-heading-m').text()).to.include(`Enter a valid Test reference label`)
+      expect($('.govuk-heading-m').text()).to.include('Enter a valid Test reference label')
     })
   })
 
@@ -105,7 +105,7 @@ describe('product reference post controller', function () {
       nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
       nock(config.ADMINUSERS_URL).get(`/v1/api/services?gatewayAccountId=${product.gateway_account_id}`).reply(200, service)
 
-      const referenceNumber = 'This_is_a_256_characters_long_String_This_is_a_256_characters_long_String_This_is_a_256_characters_long_String_This_is_a_256_characters_long_String_This_is_a_256_characters_long_String_This_is_a_256_characters_long_String_This_is_a_256_characters_long_Stri'
+      const referenceNumber = 'This_is_a_51_characters_long_String_This_is_a_51_ch'
       supertest(createAppWithSession(getApp()))
         .post(paths.pay.reference.replace(':productExternalId', product.external_id))
         .send({
@@ -166,7 +166,7 @@ describe('product reference post controller', function () {
       expect($('h1').text()).to.include(product.name)
       expect($('p#description').text()).to.include(product.description)
       expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
-      expect($('.govuk-heading-m').text()).to.include(`You can’t use any of the following characters`)
+      expect($('.govuk-heading-m').text()).to.include('You can’t use any of the following characters')
     })
   })
 })


### PR DESCRIPTION
Current validation on payment link reference doesn't make sense, there
is both client and server side validation (with useful error messages)
for some validation -- there appears to be no client side validation for
length; the `max-length` HTML attribute is used which won't allow the
user to enter something too long but will also not give any meaningful
feedback (instead just truncating whatever is entered).

* Remove max length assertion - allow the server side
validation to provide the user with a meaningful message
* Reduce the max length to 50, the Products database stores this in
`reference_number` which is currently restricted to `VARCHAR(50)`
https://github.com/alphagov/pay-products/blob/master/src/main/resources/migrations/00029_alter_column_reference_number_length_payments.sql#L4

---

Note Connector allows references of up to 250 characters `VARCHAR(250)`
https://github.com/alphagov/pay-connector/blob/master/src/main/resources/migrations.xml#L68,
there doesn't seem to be a reason Connector should support this and
Products shouldn't. These database columns should and related
validations should be brought into parity with each other.

--- 

TL;DR client side validation for length doesn't exist, remove this. Products database
is currently configured to `VARCHAR(50)`, initially limit reference to 50 characters.