### PR TITLE
BAU Bump pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2149,14 +2149,14 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.24.0.tgz",
-      "integrity": "sha512-4RqTvS0/H9L1pz5+Cn5dIe3EaNxSqOBQBHeug4cVGSbSGVnDzccdvCj4d9URmqElvXLPbh5s5U0EZHtq1cnaOg==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-2.25.0.tgz",
+      "integrity": "sha512-89MvXzEFj2UmuvetDZmyERqvYZ8Wgi4rOhHtqnDDtbpZeTB+SBbnGr+KVSAT5ay4mbkW3QLXHJ9hEeTxb0oKfg==",
       "requires": {
         "lodash": "4.17.15",
-        "moment-timezone": "0.5.27",
+        "moment-timezone": "0.5.28",
         "rfc822-validate": "1.0.0",
-        "slugify": "1.3.6",
+        "slugify": "1.4.0",
         "winston": "3.2.1"
       }
     },
@@ -11565,9 +11565,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-timezone": {
-      "version": "0.5.27",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.27.tgz",
-      "integrity": "sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==",
+      "version": "0.5.28",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.28.tgz",
+      "integrity": "sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==",
       "requires": {
         "moment": ">= 2.9.0"
       }
@@ -14948,9 +14948,9 @@
       }
     },
     "slugify": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.3.6.tgz",
-      "integrity": "sha512-wA9XS475ZmGNlEnYYLPReSfuz/c3VQsEMoU43mi6OnKMCdbnFXd4/Yg7J0lBv8jkPolacMpOrWEaoYxuE1+hoQ=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.4.0.tgz",
+      "integrity": "sha512-FtLNsMGBSRB/0JOE2A0fxlqjI6fJsgHGS13iTuVT28kViI4JjUiNqp/vyis0ZXYcMnpR3fzGNkv+6vRlI2GwdQ=="
     },
     "smart-buffer": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "2.24.0",
+    "@govuk-pay/pay-js-commons": "2.25.0",
     "@sentry/node": "5.13.1",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
- Bump `pay-js-commons` from 2.24.0 -> 2.25.0