### PR TITLE
PP-6254 Add carbon-relay

### DIFF
--- a/env-map.yml
+++ b/env-map.yml
@@ -2,6 +2,8 @@ env_vars:
   ADMINUSERS_URL:               '.[][] | select(.name == "app-catalog") | .credentials.adminusers_url'
   PRODUCTS_URL:                 '.[][] | select(.name == "app-catalog") | .credentials.products_url'
   SELFSERVICE_TRANSACTIONS_URL: '.[][] | select(.name == "app-catalog") | .credentials.selfservice_transactions_url'
+  METRICS_HOST:                 '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_route'
+  METRICS_PORT:                 '.[][] | select(.name == "app-catalog") | .credentials.carbon_relay_port'
   SENTRY_DSN:                   '.[][] | select(.name == "products-ui-secret-service") | .credentials.sentry_dsn'
   SESSION_ENCRYPTION_KEY:       '.[][] | select(.name == "products-ui-secret-service") | .credentials.session_encryption_key'
   ANALYTICS_TRACKING_ID:        '.[][] | select(.name == "products-ui-secret-service") | .credentials.analytics_tracking_id'

--- a/manifest.yml
+++ b/manifest.yml
@@ -19,14 +19,15 @@ applications:
       DISABLE_APPMETRICS: ((disable_appmetrics))
       DISABLE_INTERNAL_HTTPS: ((disable_internal_https))
       DISABLE_REQUEST_LOGGING: ((disable_request_logging))
-      METRICS_HOST: ((metrics_host))
       NODE_ENV: production
       NODE_WORKER_COUNT: '1'
 
-      # These are taken via bound service, see `env-map.yml`
+      # These are provided by app-catalog, see `env-map.yml`
       ADMINUSERS_URL: ""
       PRODUCTS_URL: ""
       SELFSERVICE_TRANSACTIONS_URL: ""
+      METRICS_HOST: ""
+      METRICS_PORT: ""
 
       # These are provided by products-ui-secret-service, see `env-map.yml`
       SESSION_ENCRYPTION_KEY: ""


### PR DESCRIPTION
Set the METRICS_HOST and METRICS_PORT from the app-catalog to send
metrics to the carbon-relay app.