### PR TITLE
PP-6869 Tell search engines not to index card payment pages

### DIFF
--- a/app/views/includes/head.njk
+++ b/app/views/includes/head.njk
@@ -36,3 +36,4 @@
   ga('govuk_shared.send', 'pageview'); #}
 </script>
 {% endif %}
+<meta name="robots" content="noindex, nofollow">


### PR DESCRIPTION
Add `<meta name="robots" content="noindex, nofollow">` to all payment link, prototype and demo payment pages so search engines don’t index them.

This is the approach specified by:
https://www.gov.uk/service-manual/technology/get-a-domain-name#telling-search-engines-not-to-index-pages