### PR TITLE
PP-6869 Remove robots.txt file

### DIFF
--- a/app/assets/robots.txt
+++ b/app/assets/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
https://www.gov.uk/service-manual/technology/get-a-domain-name#telling-search-engines-not-to-index-pages says to use `<meta name="robots" content="noindex, nofollow">` to tell search engines not to index our pages. Additionally, it says not to use `robots.txt` to prevent crawling because this stops the `noindex` directive from being seen by search engines.

We added `<meta name="robots" content="noindex, nofollow">` in commit 38f1430d901f0c85ee1c6669c4a97babc818d45d. This commit completes the work by removing the `robots.txt` file.