### PR TITLE
PP-7324 Check for payment reference that are just white space

### DIFF
--- a/app/controllers/product_reference/post_product_reference_controller.js
+++ b/app/controllers/product_reference/post_product_reference_controller.js
@@ -13,7 +13,7 @@ module.exports = (req, res) => {
   }
 
   const referenceNumber = req.body['payment-reference']
-  if (!referenceNumber) {
+  if (!referenceNumber || referenceNumber.trim() === "") {
     req.errorMessage = `<h2 class="govuk-heading-m govuk-!-margin-bottom-0">${res.locals.__p('fieldValidation.generic').replace('%s', product.reference_label)}</h2>`
     return index(req, res)
   }

--- a/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
+++ b/test/unit/controllers/payment_reference/post_product_reference_controller_test.js
@@ -94,6 +94,43 @@ describe('product reference post controller', function () {
     })
   })
 
+  describe('when reference field is only white space', function () {
+    before(done => {
+      product = productFixtures.validCreateProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'Test reference label'
+      }).getPlain()
+      service = serviceFixtures.validServiceResponse().getPlain()
+      nock(config.PRODUCTS_URL).get(`/v1/api/products/${product.external_id}`).reply(200, product)
+      nock(config.ADMINUSERS_URL).get(`/v1/api/services?gatewayAccountId=${product.gateway_account_id}`).reply(200, service)
+
+      supertest(createAppWithSession(getApp()))
+        .post(paths.pay.reference.replace(':productExternalId', product.external_id))
+        .send({
+          'payment-reference': "     ",
+          csrfToken: csrf().create('123')
+        })
+        .end((err, res) => {
+          response = res
+          $ = cheerio.load(res.text || '')
+          done(err)
+        })
+    })
+
+    it('should respond with code: 200 OK', () => {
+      expect(response.statusCode).to.equal(200)
+    })
+
+    it('should render product reference start page with error message', () => {
+      expect($('title').text()).to.include(service.service_name.en)
+      expect($('h1').text()).to.include(product.name)
+      expect($('p#description').text()).to.include(product.description)
+      expect($('form').attr('action')).to.equal(`/pay/reference/${product.external_id}`)
+      expect($('.govuk-heading-m').text()).to.include('Enter a valid Test reference label')
+    })
+  })
+
   describe('when reference field exceeds max length', function () {
     before(done => {
       product = productFixtures.validCreateProductResponse({


### PR DESCRIPTION
Sending a payment reference of just white space characters to Publicapi
to create a payment will return an error `Missing mandatory attribute:
reference`. Add a check to the payment reference to ensure it is not
only white space characters.

## WHAT ##
At present its possible to enter `"    "` in the reference field and go through create payment which then displays
```
An error occurred:
Sorry, we’re unable to process your request. Try again later.
```
This was caught but this Sentry error: https://sentry.io/organizations/govuk-pay/issues/1980313985/?project=5480169&referrer=slack

You can test this behaviour with a simple test to publicapi
```
{
	"amount": 10,
	"reference": "       ",
	"description": "testing this out",
	"return_url": "https://www.google.com"
}

{
    "field": "reference",
    "code": "P0101",
    "description": "Missing mandatory attribute: reference"
}
```