### PR TITLE
PP-7698 Add support for AGENT_INITATED_MOTO payments

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "package-lock.json",
     "lines": null
   },
-  "generated_at": "2020-10-07T12:46:29Z",
+  "generated_at": "2021-02-05T12:07:26Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -174,7 +174,7 @@
       {
         "hashed_secret": "cb9f57fdfdc1628c165407930d5cfb5fe33f7ade",
         "is_verified": false,
-        "line_number": 201,
+        "line_number": 279,
         "type": "Hex High Entropy String"
       }
     ],

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ User interface app for product payments (Prototype/Demo/Ad-hoc ..etc) integrated
 | `NODE_WORKER_COUNT`            | Default `1`
 | `PORT`                         | Default `3000`
 | `PRODUCTS_URL`                 | 
+| `SELFSERVICE_DASHBOARD_URL`    | 
 | `SELFSERVICE_TRANSACTIONS_URL` | 
 | `SESSION_ENCRYPTION_KEY`       | 
 

--- a/app/controllers/make_payment_controller.js
+++ b/app/controllers/make_payment_controller.js
@@ -11,8 +11,8 @@ const errorMessagePath = 'error.internal' // This is the object notation to stri
 module.exports = (req, res) => {
   const product = req.product
   const correlationId = req.correlationId
-  const paymentAmount = req.paymentAmount // should be undefined for non adhoc payments
-  const referenceNumber = req.referenceNumber // undefined for non ADHOC or ADHOC with reference disabled
+  const paymentAmount = req.paymentAmount // may be undefined
+  const referenceNumber = req.referenceNumber // may be undefined
   if (product) {
     logger.info(`[${correlationId}] creating charge for product ${product.name}`)
     return productsClient.payment.create(product.externalId, paymentAmount, referenceNumber)

--- a/app/controllers/payment_complete_controller.js
+++ b/app/controllers/payment_complete_controller.js
@@ -27,6 +27,7 @@ module.exports = (req, res) => {
       res.redirect(product.returnUrl)
       break
     case ('ADHOC'):
+    case ('AGENT_INITIATED_MOTO'):
       lodash.get(payment, 'govukStatus', '').toLowerCase() === 'success' ? paymentStatus(req, res) : res.redirect(pay.product.replace(':productExternalId', product.externalId))
       break
     default:

--- a/app/controllers/payment_status_controller.js
+++ b/app/controllers/payment_status_controller.js
@@ -6,6 +6,7 @@ const currencyFormatter = require('currency-formatter')
 // Custom dependencies
 const response = require('../utils/response').response
 const { pay } = require('../paths')
+const { SELFSERVICE_DASHBOARD_URL } = require('../../config/index')
 
 function asGBP (amountInPence) {
   return currencyFormatter.format((amountInPence / 100).toFixed(2), { code: 'GBP' })
@@ -25,6 +26,10 @@ module.exports = (req, res) => {
     data.payment = {
       reference: reference,
       amount: asGBP(payment.amount)
+    }
+    if (product.type === 'AGENT_INITIATED_MOTO') {
+      data.payment.agentInitiatedMoto = true;
+      data.payment.dashboardLink = SELFSERVICE_DASHBOARD_URL;
     }
     return response(req, res, 'pay/confirmation', data)
   } else {

--- a/app/controllers/pre_payment_controller.js
+++ b/app/controllers/pre_payment_controller.js
@@ -21,6 +21,7 @@ module.exports = (req, res) => {
     case ('PROTOTYPE'):
       return makePayment(req, res)
     case ('ADHOC'):
+    case ('AGENT_INITIATED_MOTO'):
       if (product.reference_enabled) {
         return productReferenceCtrl.index(req, res)
       } else {

--- a/app/routes.js
+++ b/app/routes.js
@@ -60,7 +60,7 @@ module.exports.bind = function (app) {
   app.get(demoPayment.failure, failedCtrl)
   app.get(demoPayment.success, successCtrl)
 
-  // ADHOC SPECIFIC SCREENS
+  // ADHOC AND AGENT_INITIATED_MOTO SPECIFIC SCREENS
   app.post(pay.product, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, adhocPaymentCtrl.postIndex)
 
   // route to gov.uk 404 page

--- a/app/views/pay/confirmation.njk
+++ b/app/views/pay/confirmation.njk
@@ -1,7 +1,12 @@
 {% extends "../layout.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% block pageTitle %}
+{% if payment.agentInitiatedMoto %}
+{{ __p('confirmation.titleMoto') }} - {{serviceName}} - GOV.UK Pay
+{% else %}
 {{ __p('confirmation.title') }} - {{serviceName}} - GOV.UK Pay
+{% endif %}
 {% endblock %}
 
 {% block contentBody %}
@@ -9,17 +14,30 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-panel govuk-panel--confirmation">
       <h2 class="govuk-panel__title">
+        {% if payment.agentInitiatedMoto %}
+        {{ __p('confirmation.titleMoto') }}
+        {% else %}
         {{ __p('confirmation.title') }}
+        {% endif %}
       </h2>
       <div class="govuk-panel__body">
-         {{ __p('confirmation.referenceNumber') }} <br>
+        {% if payment.agentInitiatedMoto %}
+        {{ __p('confirmation.referenceNumberMoto') }}
+        {% else %}
+        {{ __p('confirmation.referenceNumber') }}
+        {% endif %}
+        <br>
         <strong class="bold" id="payment-reference">{{ payment.reference }}</strong>
       </div>
     </div>
 
     <h2 class="govuk-heading-m govuk-!-margin-top-6">{{ __p('confirmation.next.title') }}</h2>
     <p class="govuk-body">
+      {% if payment.agentInitiatedMoto %}
+      {{ __p('confirmation.next.bodyMoto') }}
+      {% else %}
       {{ __p('confirmation.next.body') }}
+      {% endif %}
     </p>
 
     <h2 class="govuk-heading-m">{{ __p('confirmation.paymentSummary.title') }}</h2>
@@ -38,4 +56,11 @@
     </table>
   </div>
 </div>
+{% if payment.agentInitiatedMoto %}
+  {{ govukButton({
+      text: __p('confirmation.goToDashboard'),
+      href: payment.dashboardLink,
+      classes: "dashboard-link"
+    }) }}
+{% endif %}
 {% endblock %}

--- a/config/index.js
+++ b/config/index.js
@@ -1,6 +1,7 @@
 'use strict'
 
 exports.CORRELATION_HEADER = process.env.CORRELATION_HEADER_NAME || 'x-request-id'
+exports.SELFSERVICE_DASHBOARD_URL = process.env.SELFSERVICE_DASHBOARD_URL
 exports.SELFSERVICE_TRANSACTIONS_URL = process.env.SELFSERVICE_TRANSACTIONS_URL
 exports.PRODUCTS_URL = process.env.PRODUCTS_URL
 exports.DOCS_URL = 'https://docs.payments.service.gov.uk'

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -19,16 +19,20 @@
   },
   "confirmation": {
     "title": "Roedd eich taliad yn llwyddiannus",
+    "titleMoto": "Roedd y taliad yn llwyddiannus",
     "referenceNumber": "Rhif cyfeirnod eich taliad yw",
+    "referenceNumberMoto": "Rhif cyfeirnod y taliad yw",
     "next": {
       "title": "Beth sy’n digwydd nesaf",
-      "body": "Rydym wedi anfon e-bost atoch yn cadarnhau eich bod wedi gwneud taliad."
+      "body": "Rydym wedi anfon e-bost atoch yn cadarnhau eich bod wedi gwneud taliad.",
+      "bodyMoto": "Rydym wedi anfon e-bost at y defnyddiwr yn cadarnhau eich bod wedi gwneud taliad."
     },
     "paymentSummary": {
       "title": "Crynodeb o’r taliad",
       "description": "Taliad am:",
       "amount": "Cyfanswm:"
-    }
+    },
+    "goToDashboard": "Ewch i’r dangosfwrdd"
   },
   "failed": {
     "title": "Mae eich taliad wedi cael ei wrthod",

--- a/locales/en.json
+++ b/locales/en.json
@@ -19,16 +19,20 @@
   },
   "confirmation": {
     "title": "Your payment was successful",
+    "titleMoto": "The payment was successful",
     "referenceNumber": "Your payment reference number is",
+    "referenceNumberMoto": "The payment reference number is",
     "next": {
       "title": "What happens next",
-      "body": "We have sent you a confirmation email."
+      "body": "We have sent you a confirmation email.",
+      "bodyMoto": "We have sent the user a confirmation email."
     },
     "paymentSummary": {
       "title": "Payment summary",
       "description": "Payment for:",
       "amount": "Total amount:"
-    }
+    },
+    "goToDashboard": "Go to the dashboard"
   },
   "failed": {
     "title": "Your payment has been declined",

--- a/test/test.env
+++ b/test/test.env
@@ -1,4 +1,5 @@
 PRODUCTS_URL=http://localhost:18000
+SELFSERVICE_DASHBOARD_URL=http://localhost:9400/dashboard
 SELFSERVICE_TRANSACTIONS_URL=http://localhost:9400/transactions
 SECURE_COOKIE_OFF=true
 COOKIE_MAX_AGE=10800000


### PR DESCRIPTION
Add support for `AGENT_INITIATED_MOTO` payments. These present the same user journey as `ADHOC` payments but with some changes to the confirmation page.