### PR TITLE
ZD_4487202 Bump pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,9 +1403,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.1.0.tgz",
-      "integrity": "sha512-SNwNRRjJOAeE6tMiwoErj5nfQPiEkwJfw1A5tEDLgBGDT85CUqHdmYRdtcL5znDcvrFzX2tzOTiqpUeHAIkPhA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.0.8.tgz",
+      "integrity": "sha512-53Tlc0dlVH9Yhq2ts0m0x4ggAHaEx2LjKk55kuNgNydBeUCBEg9sZ1uuZOnastRHdgRzqw+w82Yt2HUb1RbU+Q==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.33",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "3.1.0",
+    "@govuk-pay/pay-js-commons": "3.0.8",
     "@sentry/node": "6.2.1",
     "appmetrics": "5.1.1",
     "appmetrics-statsd": "3.0.0",


### PR DESCRIPTION
This will pick up the latest custom branding changes. Note that `3.1.0`
was created some time ago in error, this is not downgrading
pay-js-commons, version `3.0.8` is the latest.