### PR TITLE
PP-8095 Add security.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,7 @@ npm run compile && npm test
 | `PACT_BROKER_USERNAME`  | 
 | `PACT_CONSUMER_TAG`     | 
 | `PACT_CONSUMER_VERSION` | 
+
+## Vulnerability Disclosure
+
+GOV.UK Pay aims to stay secure for everyone. If you are a security researcher and have discovered a security vulnerability in this code, we appreciate your help in disclosing it to us in a responsible manner. Please refer to our [vulnerability disclosure policy](https://www.gov.uk/help/report-vulnerability) and our [security.txt](https://vdp.cabinetoffice.gov.uk/.well-known/security.txt) file for details.

--- a/app/routes.js
+++ b/app/routes.js
@@ -63,6 +63,11 @@ module.exports.bind = function (app) {
   // ADHOC AND AGENT_INITIATED_MOTO SPECIFIC SCREENS
   app.post(pay.product, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, adhocPaymentCtrl.postIndex)
 
+  // security.txt — https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html
+  const securitytxt = 'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'
+  app.get('/.well-known/security.txt', (req, res) => res.redirect(securitytxt))
+  app.get('/security.txt', (req, res) => res.redirect(securitytxt))
+
   // route to gov.uk 404 page
   // this has to be the last route registered otherwise it will redirect other routes
   app.all('*', (req, res) => res.redirect('https://www.gov.uk/404'))


### PR DESCRIPTION
Make `/.well-known/security.txt` and `/security.txt` redirect to https://vdp.cabinetoffice.gov.uk/.well-known/security.txt.

Update `README.md` to reference the Cabinet Office CDIO Cyber Security vulnerability disclosure policy and security.txt file rather than the GOV.UK Pay security vulnerability email address.