### PR TITLE
PP-8300 Confirm reference if found to be a potential PAN

### DIFF
--- a/app/browsered/field-validation-checks.js
+++ b/app/browsered/field-validation-checks.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const Luhn = require('luhn-js')
+
 // Constants
 const MAX_AMOUNT = 100000
 
@@ -32,4 +34,16 @@ exports.isNaxsiSafe = (value, message) => {
   } else {
     return false
   }
+}
+
+exports.isAPotentialPAN = (value) => {
+  const referenceWithoutSpaceAndHyphen = value.replace(/[\s-]/g, '')
+
+  const NUMBERS_ONLY = /^\d+$/
+  if (NUMBERS_ONLY.test(referenceWithoutSpaceAndHyphen) &&
+      referenceWithoutSpaceAndHyphen.length >= 12 && referenceWithoutSpaceAndHyphen.length <= 19) {
+    return Luhn.isValid(referenceWithoutSpaceAndHyphen)
+  }
+
+  return false
 }

--- a/app/controllers/product-reference/get-product-reference.controller.js
+++ b/app/controllers/product-reference/get-product-reference.controller.js
@@ -2,6 +2,7 @@
 
 const logger = require('../../utils/logger')(__filename)
 const response = require('../../utils/response').response
+const { pay } = require('../../paths')
 const { getSessionVariable } = require('../../utils/cookie')
 
 module.exports = (req, res) => {
@@ -27,6 +28,13 @@ module.exports = (req, res) => {
     }
   }
 
-  logger.info(`[${correlationId}] initiating product payment for ${product.externalId}`)
+  if (req.confirmReferenceNumber) {
+    logger.info(`[${correlationId}] Potential PAN number entered in the reference field for ${product.externalId}. `)
+    data.confirmReferenceNumber = req.confirmReferenceNumber
+    data.backToStartPage = pay.product.replace(':productExternalId', product.externalId)
+  } else {
+    logger.info(`[${correlationId}] initiating product payment for ${product.externalId}`)
+  }
+
   response(req, res, 'reference/index', data)
 }

--- a/app/views/reference/index.njk
+++ b/app/views/reference/index.njk
@@ -1,6 +1,7 @@
 {% extends "../layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 
 {% block pageTitle %}
   {{ __p('adhoc.title') }} {{ serviceName }}
@@ -19,26 +20,58 @@
     <form action="/pay/reference/{{ productExternalId }}" method="post" name="referencePaymentForm" class="push-bottom" data-validate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
-      {{ govukInput({
-        label: {
-          text: paymentReferenceLabel,
-          classes: "govuk-!-font-weight-bold"
-        },
-        hint: {
-          text: paymentReferenceHint
-        },
-        id: "payment-reference",
-        name: "payment-reference",
-        classes: "govuk-!-width-one-third",
-        value: referenceNumber,
-        attributes: {
-          autofocus: "",
-          "data-validate": "isNaxsiSafe"
-        }
-      }) }}
-      {{ govukButton({
-        text: __p('buttons.continue')
-      }) }}
+      {% if confirmReferenceNumber %}
+        <input id="payment-reference" name="payment-reference" type="hidden" value="{{ referenceNumber }}"/>
+        <input id="payment-reference-confirmed" name="payment-reference-confirmed" type="hidden" value="true"/>
+        <div class="govuk-form-group">
+            <label class="govuk-label govuk-!-font-weight-bold" for="payment-reference"> {{paymentReferenceLabel}} </label>
+            <div id="event-name-hint" class="govuk-hint">
+                {{paymentReferenceHint}}
+            </div>
+            <div class="govuk-inset-text">
+                <p class="govuk-body">
+                    <b> {{referenceNumber}} </b>
+                </p>
+            </div>
+        </div>
+
+        <h2 class="govuk-heading-m">{{ __p('fieldValidation.potentialPANInReferenceTitle') }}</h2>
+        <p class="govuk-body" id="potential-pan-as-reference">{{ __p('fieldValidation.potentialPANInReference') }}</p>
+
+        {{ govukButton({
+          text: __p('buttons.edit'),
+          id: "reference__edit",
+          href: backToStartPage,
+          classes: "govuk-button--secondary"
+        }) }}
+        {{ govukButton({
+          text: __p('buttons.confirmAndContinue'),
+          id: "reference__confirm-and-continue"
+        }) }}
+
+      {% else %}
+          {{ govukInput({
+            label: {
+              text: paymentReferenceLabel,
+              classes: "govuk-!-font-weight-bold"
+            },
+            hint: {
+              text: paymentReferenceHint
+            },
+            id: "payment-reference",
+            name: "payment-reference",
+            classes: "govuk-!-width-one-third",
+            value: referenceNumber,
+            attributes: {
+              autofocus: "",
+              "data-validate": "isNaxsiSafe"
+            }
+          }) }}
+          {{ govukButton({
+            text: __p('buttons.continue')
+          }) }}
+
+      {% endif %}
     </form>
   </div>
 </div>

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -10,7 +10,9 @@
   },
   "buttons": {
     "proceed": "Mynd ati i dalu",
-    "continue": "Parhau"
+    "continue": "Parhau",
+    "confirmAndContinue": "Cadarnhau a parhau",
+    "edit": "golygu"
   },
   "error": {
     "title": "Digwyddodd gwall:",
@@ -46,6 +48,8 @@
     "currency": "Dewiswch swm mewn punnoedd a cheiniogau drwy ddefnyddio digidau a phwynt degol. Er enghraifft “10.50”",
     "isAboveMaxAmount": "Dewiswch swm sy'n llai na £%s",
     "isGreaterThanMaxLengthChars": "Mae'r testun yn rhy hir. Ni all fod yn fwy na 50 o nodau.",
-    "invalidCharacters": "Ni allwch ddefnyddio unrhyw rai o'r nodau canlynol < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
+    "invalidCharacters": "Ni allwch ddefnyddio unrhyw rai o'r nodau canlynol < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]",
+    "potentialPANInReferenceTitle": "Ydych chi’n siŵr mae rhif cyfeirnod yw hwn? ",
+    "potentialPANInReference": "Gwiriwch eich bod wedi nodi’r rhif yn gywir cyn gwneud y taliad. Peidiwch â nodi’ch rhif cerdyn debyd neu gredyd."
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -10,7 +10,9 @@
   },
   "buttons": {
     "proceed": "Proceed to payment",
-    "continue": "Continue"
+    "continue": "Continue",
+    "confirmAndContinue": "Confirm and continue",
+    "edit": "Edit"
   },
   "error": {
     "title": "An error occurred:",
@@ -46,6 +48,8 @@
     "currency": "Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”",
     "isAboveMaxAmount": "Choose an amount under £%s",
     "isGreaterThanMaxLengthChars": "Text is too long. It can be no more than 50 characters.",
-    "invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
+    "invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]",
+    "potentialPANInReferenceTitle": "Are you sure this is a reference number?",
+    "potentialPANInReference": "Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11297,6 +11297,11 @@
       "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
       "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
+    "luhn-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/luhn-js/-/luhn-js-1.1.2.tgz",
+      "integrity": "sha512-GdINoHY50s4Zkhvmt6Pss/8ZwVxIOLsMHuJCg6EDcT1heSt4hM2V+7aKCihemn8rI0n22+lxqomzgvWDzMyEuQ=="
+    },
     "macos-release": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "govuk-frontend": "^3.13.0",
     "i18n": "^0.13.3",
     "lodash": "4.17.x",
+    "luhn-js": "^1.1.2",
     "minimist": "1.2.x",
     "morgan": "1.10.x",
     "nunjucks": "^3.2.2",

--- a/test/unit/browsered/field-validation-checks.test.js
+++ b/test/unit/browsered/field-validation-checks.test.js
@@ -4,7 +4,7 @@
 const { expect } = require('chai')
 
 // Local dependencies
-const { isAboveMaxAmount } = require('../../../app/browsered/field-validation-checks')
+const { isAboveMaxAmount, isAPotentialPAN } = require('../../../app/browsered/field-validation-checks')
 const i18n = require('../../../locales/en.json')
 
 describe('field validation checks', () => {
@@ -15,6 +15,29 @@ describe('field validation checks', () => {
 
     it('should not return false if it is not passed an currency string', () => {
       expect(isAboveMaxAmount('100,000 pounds sterling', i18n.fieldValidation.isAboveMaxAmount)).to.equal(false)
+    })
+  })
+  describe('Potential card number', () => {
+    it('should return true if reference passes luhn check', () => {
+      expect(isAPotentialPAN('4242424242424242')).to.equal(true)
+    })
+    it('should return true if reference has characters [- or space] and passes luhn check', () => {
+      expect(isAPotentialPAN('4242 4242 4242-42-42')).to.equal(true)
+    })
+    it('should return false if reference is less than 12 digits', () => {
+      expect(isAPotentialPAN('42424242424')).to.equal(false)
+    })
+    it('should return false if reference has more than 19 digits', () => {
+      expect(isAPotentialPAN('4242 4242 4242 4242 4242 4242')).to.equal(false)
+    })
+    it('should return false if reference fails luhn check', () => {
+      expect(isAPotentialPAN('42424242424211')).to.equal(false)
+    })
+    it('should return false if reference has characters [- or space] and but fails luhn check', () => {
+      expect(isAPotentialPAN('4242-4242-4242-11')).to.equal(false)
+    })
+    it('should return false for reference with characters', () => {
+      expect(isAPotentialPAN('REF123456')).to.equal(false)
     })
   })
 })


### PR DESCRIPTION
## WHAT
- Checks reference entered for a potential PAN and asks users for confirmation
   - only numbers (with special characters '-' and space) are considered
   - and reference number of length between 12 and 19 digits excluding special characters (card number lengths across brands) are checked for potential PAN

- Adds new library luhn-js to check reference for potential PAN using luhn algorithm


**_Note:_ Content still to be finalised**



## Screenshots
**Confirmation page**

![image](https://user-images.githubusercontent.com/40598480/128140474-8e65114b-8260-4927-b340-5abf43071514.png)

**on edit, takes back to reference page**

![image](https://user-images.githubusercontent.com/40598480/128140543-e85a8b6c-8be7-43b4-b1bd-524d9322205f.png)
