### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ node_modules_local
 pacts/
 coverage
 *.log
-.pre-commit-config.yaml
 .env
 
 # IntelliJ gubbins

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": "package-lock.json",
-    "lines": null
-  },
-  "generated_at": "2021-02-05T12:07:26Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,139 +53,199 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "package-lock.json"
+      ]
+    }
+  ],
   "results": {
-    "test/unit/client/product_client/payment/create_test.js": [
+    ".pre-commit-config.yaml": [
       {
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
+        "line_number": 3
       }
     ],
-    "test/unit/client/product_client/payment/get_by_payment_external_id_test.js": [
+    "test/unit/client/product.client/payment/create.pact.test.js": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/payment/create.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String"
+        "line_number": 21
       },
       {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/client/product_client/payment/get_by_product_external_id_test.js": [
-      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/payment/create.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 22,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Secret Keyword"
+        "line_number": 21
       }
     ],
-    "test/unit/client/product_client/product/create_test.js": [
+    "test/unit/client/product.client/payment/get-by-payment-external-id.pact.test.js": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/payment/get-by-payment-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String"
+        "line_number": 21
       },
       {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/client/product_client/product/delete_test.js": [
-      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/payment/get-by-payment-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Secret Keyword"
+        "line_number": 21
       }
     ],
-    "test/unit/client/product_client/product/disable_test.js": [
+    "test/unit/client/product.client/payment/get-by-product-external-id.pact.test.js": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/payment/get-by-product-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 19,
-        "type": "Hex High Entropy String"
+        "line_number": 22
       },
       {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Secret Keyword"
-      }
-    ],
-    "test/unit/client/product_client/product/get_by_gateway_account_id_test.js": [
-      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/payment/get-by-product-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String"
-      },
-      {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
+        "line_number": 22
       }
     ],
-    "test/unit/client/product_client/product/get_by_product_external_id_test.js": [
+    "test/unit/client/product.client/product/create.pact.test.js": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/product/create.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Hex High Entropy String"
+        "line_number": 21
       },
       {
-        "hashed_secret": "efef03b9a936bbefd3357128b2b8d6a757bc6500",
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/product/create.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
+        "line_number": 21
       }
     ],
-    "test/unit/controllers/payment_complete_controller_test.js": [
+    "test/unit/client/product.client/product/delete.pact.test.js": [
       {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/product/delete.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/product/delete.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "test/unit/client/product.client/product/disable.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/product/disable.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 19
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/product/disable.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "test/unit/client/product.client/product/get-by-gateway-account-id.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/product/get-by-gateway-account-id.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/product/get-by-gateway-account-id.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "test/unit/client/product.client/product/get-by-product-external-id.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/client/product.client/product/get-by-product-external-id.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 21
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "test/unit/client/product.client/product/get-by-product-external-id.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 21
+      }
+    ],
+    "test/unit/controllers/payment-complete.controller.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "test/unit/controllers/payment-complete.controller.test.js",
         "hashed_secret": "cb9f57fdfdc1628c165407930d5cfb5fe33f7ade",
         "is_verified": false,
-        "line_number": 279,
-        "type": "Hex High Entropy String"
-      }
-    ],
-    "test/unit/utils/cookie_test.js": [
-      {
-        "hashed_secret": "ef5c25da3f68da43b33a9bc96de633756beb2d88",
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Secret Keyword"
+        "line_number": 121
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-13T15:43:47Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`
- Update the `.gitignore` file to allow tracking of a `.pre-commit.yaml`