### PR TITLE
PP-8551 Set google reCATPCHA URLs with environments

### DIFF
--- a/app/utils/captcha.js
+++ b/app/utils/captcha.js
@@ -1,9 +1,7 @@
 const request = require('request')
 const logger = require('./logger')(__filename)
 
-const GOOGLE_RECAPTCHA_VERIFY_URL = 'https://www.recaptcha.net/recaptcha/api/siteverify'
-
-const { GOOGLE_RECAPTCHA_SECRET_KEY } = process.env
+const { GOOGLE_RECAPTCHA_SECRET_KEY, GOOGLE_RECAPTCHA_VERIFY_URL } = process.env
 const HTTP_SUCCESS_CODE = 200
 
 function verifyCAPTCHAToken(token) {

--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -5,7 +5,7 @@
 {% block bodyEnd %}
   {{ super() }}
   {% if product.requireCaptcha %}
-  <script src="https://www.recaptcha.net/recaptcha/api.js" async defer></script>
+  <script src="{{ GOOGLE_RECAPTCHA_SITE_WIDGET_URL }}" async defer></script>
   {% endif %}
 {% endblock %}
 

--- a/server.js
+++ b/server.js
@@ -67,6 +67,7 @@ function initialiseGlobalMiddleware (app) {
     res.locals.routes = router.paths
     res.locals.analyticsTrackingId = ANALYTICS_TRACKING_ID
     res.locals.GOOGLE_RECAPTCHA_SITE_KEY = process.env.GOOGLE_RECAPTCHA_SITE_KEY
+    res.locals.GOOGLE_RECAPTCHA_SITE_WIDGET_URL = process.env.GOOGLE_RECAPTCHA_SITE_WIDGET_URL
     noCache(res)
     next()
   })

--- a/test/test.env
+++ b/test/test.env
@@ -11,3 +11,5 @@ NODE_TEST_MODE=true
 NODE_ENV=test
 ADMINUSERS_URL=http://localhost:9700
 GOOGLE_RECAPTCHA_SECRET_KEY=8Pf-i72rjkwfmjwfi72rfkjwefmjwef
+GOOGLE_RECAPTCHA_VERIFY_URL=https://www.recaptcha.net/recaptcha/api/siteverify
+GOOGLE_RECAPTCHA_SITE_WIDGET_URL=https://www.recaptcha.net/recaptcha/api.js


### PR DESCRIPTION
Enterprise and basic Google reCAPTHCA target different validation
endpoints (either hosted by enterprise or the standard api for basic)
and load different widgets.

Allow environments to set these.