### PR TITLE
PP-8695: Remove Jenkins ECS deploys step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,13 +78,12 @@ pipeline {
         }
       }
     }
-    stage('Deploy') {
+    stage('Check Pact Compatibility') {
       when {
         branch 'master'
       }
       steps {
         checkPactCompatibility("products-ui", gitCommit(), "test")
-        deployEcs("products-ui")
       }
     }
     stage('Smoke Tests') {


### PR DESCRIPTION
Jenkins doesn't deploy to ECS now and we have now removed the old EC2 based
services so the deploy step is no longer required.