### PR TITLE
PP-8688 Add support for captcha enterprise version

### DIFF
--- a/app/utils/captcha.js
+++ b/app/utils/captcha.js
@@ -1,13 +1,20 @@
 const request = require('request')
 const logger = require('./logger')(__filename)
+const urlJoin = require('url-join')
 
 const {
   GOOGLE_RECAPTCHA_SECRET_KEY,
-  GOOGLE_RECAPTCHA_VERIFY_URL,
   GOOGLE_RECAPTCHA_SITE_KEY,
-  GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION
+  GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION,
+  GOOGLE_RECAPTHCA_ENTERPRISE_PROJECT_ID
 } = process.env
 const HTTP_SUCCESS_CODE = 200
+const captchaEnterpriseUrl = formatEnterpriseUrl(GOOGLE_RECAPTHCA_ENTERPRISE_PROJECT_ID)
+const captchaBasicUrl = 'https://www.recaptcha.net/recaptcha/api/siteverify'
+
+function formatEnterpriseUrl(projectId) {
+  return urlJoin('https://recaptchaenterprise.googleapis.com/v1beta1/projects', String(projectId), 'assessments')
+}
 
 function verifyCAPTCHAEnterpriseVersion(token) {
   return new Promise((resolve, reject) => {
@@ -20,7 +27,7 @@ function verifyCAPTCHAEnterpriseVersion(token) {
       return
     }
     request.post({
-      url: GOOGLE_RECAPTCHA_VERIFY_URL,
+      url: captchaEnterpriseUrl,
       proxy: process.env.http_proxy,
       qs: {
         key: GOOGLE_RECAPTCHA_SECRET_KEY
@@ -65,7 +72,7 @@ function verifyCAPTCHATokenBasicVersion(token) {
       return
     }
     request.post({
-      url: GOOGLE_RECAPTCHA_VERIFY_URL,
+      url: captchaBasicUrl,
       proxy: process.env.http_proxy,
       formData: {
         secret: GOOGLE_RECAPTCHA_SECRET_KEY,
@@ -91,4 +98,7 @@ function verifyCAPTCHATokenBasicVersion(token) {
   })
 }
 
-module.exports = { verifyCAPTCHAToken: GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION === 'true' ? verifyCAPTCHAEnterpriseVersion : verifyCAPTCHATokenBasicVersion }
+module.exports = {
+  verifyCAPTCHAToken: GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION === 'true' ? verifyCAPTCHAEnterpriseVersion : verifyCAPTCHATokenBasicVersion,
+  formatEnterpriseUrl
+}

--- a/app/utils/captcha.js
+++ b/app/utils/captcha.js
@@ -1,13 +1,67 @@
 const request = require('request')
 const logger = require('./logger')(__filename)
 
-const { GOOGLE_RECAPTCHA_SECRET_KEY, GOOGLE_RECAPTCHA_VERIFY_URL } = process.env
+const {
+  GOOGLE_RECAPTCHA_SECRET_KEY,
+  GOOGLE_RECAPTCHA_VERIFY_URL,
+  GOOGLE_RECAPTCHA_SITE_KEY,
+  GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION
+} = process.env
 const HTTP_SUCCESS_CODE = 200
 
-function verifyCAPTCHAToken(token) {
+function verifyCAPTCHAEnterpriseVersion(token) {
   return new Promise((resolve, reject) => {
     if (!GOOGLE_RECAPTCHA_SECRET_KEY) {
       reject(new Error('reCAPTCHA secret key not set in environment'))
+      return
+    }
+    if(!token) {
+      reject(new Error('no reCAPTCHA enterprise widget token response provided'))
+      return
+    }
+    request.post({
+      url: GOOGLE_RECAPTCHA_VERIFY_URL,
+      proxy: process.env.http_proxy,
+      qs: {
+        key: GOOGLE_RECAPTCHA_SECRET_KEY
+      },
+      body: {
+        event: {
+          token: token,
+          siteKey: GOOGLE_RECAPTCHA_SITE_KEY
+        }
+      },
+      json: true
+    }, (error, response, body) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      if (response.statusCode === HTTP_SUCCESS_CODE) {
+        // https://cloud.google.com/recaptcha-enterprise/docs/interpret-assessment
+        if (!body.score || body.score < 0.9) {
+          logger.info('Failed reCAPTCHA response', {
+            tokenProperties: body.tokenProperties,
+            score: body.score,
+            reasons: body.reasons
+          })
+        }
+        resolve(true)
+        return
+      }
+      reject(new Error(`Unknown reCAPTCHA response ${response.statusCode}`))
+    })
+  })
+}
+
+function verifyCAPTCHATokenBasicVersion(token) {
+  return new Promise((resolve, reject) => {
+    if (!GOOGLE_RECAPTCHA_SECRET_KEY) {
+      reject(new Error('reCAPTCHA secret key not set in environment'))
+      return
+    }
+    if(!token) {
+      reject(new Error('no reCAPTCHA widget token response provided'))
       return
     }
     request.post({
@@ -37,4 +91,4 @@ function verifyCAPTCHAToken(token) {
   })
 }
 
-module.exports = { verifyCAPTCHAToken }
+module.exports = { verifyCAPTCHAToken: GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION === 'true' ? verifyCAPTCHAEnterpriseVersion : verifyCAPTCHATokenBasicVersion }

--- a/app/views/adhoc-payment/index.njk
+++ b/app/views/adhoc-payment/index.njk
@@ -5,7 +5,8 @@
 {% block bodyEnd %}
   {{ super() }}
   {% if product.requireCaptcha %}
-  <script src="{{ GOOGLE_RECAPTCHA_SITE_WIDGET_URL }}" async defer></script>
+  {% set googleRECAPTCHASiteWidgetUrl = "https://www.recaptcha.net/recaptcha/enterprise.js" if GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION else "https://www.recaptcha.net/recaptcha/api.js" %}
+  <script src="{{ googleRECAPTCHASiteWidgetUrl }}" async defer></script>
   {% endif %}
 {% endblock %}
 

--- a/server.js
+++ b/server.js
@@ -66,8 +66,8 @@ function initialiseGlobalMiddleware (app) {
     res.locals.asset_path = '/public/'
     res.locals.routes = router.paths
     res.locals.analyticsTrackingId = ANALYTICS_TRACKING_ID
+    res.locals.GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION = process.env.GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION === 'true'
     res.locals.GOOGLE_RECAPTCHA_SITE_KEY = process.env.GOOGLE_RECAPTCHA_SITE_KEY
-    res.locals.GOOGLE_RECAPTCHA_SITE_WIDGET_URL = process.env.GOOGLE_RECAPTCHA_SITE_WIDGET_URL
     noCache(res)
     next()
   })

--- a/test/test.env
+++ b/test/test.env
@@ -12,4 +12,4 @@ NODE_ENV=test
 ADMINUSERS_URL=http://localhost:9700
 GOOGLE_RECAPTCHA_SECRET_KEY=8Pf-i72rjkwfmjwfi72rfkjwefmjwef
 GOOGLE_RECAPTCHA_VERIFY_URL=https://www.recaptcha.net/recaptcha/api/siteverify
-GOOGLE_RECAPTCHA_SITE_WIDGET_URL=https://www.recaptcha.net/recaptcha/api.js
+GOOGLE_RECAPTHCA_ENTERPRISE_PROJECT_ID=102030

--- a/test/unit/utils/captcha.test.js
+++ b/test/unit/utils/captcha.test.js
@@ -37,4 +37,8 @@ describe('CAPTCHA verification utility', () => {
     const valid = await captcha.verifyCAPTCHAToken('a-token')
     expect(valid).to.equal(false)
   })
+
+  it('returns the captcha enterprise URL given a valid project ID', () => {
+    expect(captcha.formatEnterpriseUrl('102030')).to.equal('https://recaptchaenterprise.googleapis.com/v1beta1/projects/102030/assessments')
+  })
 })


### PR DESCRIPTION
The enterprise version of captcha expects a different interaction:
* POST body JSON instead of xhtml/form data
* secret key passed in through `?key=` paraemeter to endpoint
* returns a likelihood score rather than a simple pass/ fail response
* assesment passed as an `event` instead of a one off token

Fork the existing method to make these changes and decide whether to use
basic or enteprise with an environment flag.