### PR TITLE
PP-8684 Add footer reCAPTHCA and cookie links

### DIFF
--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -60,8 +60,16 @@
     meta: {
       items: [
         {
-          text: 'Privacy Policy',
+          text: 'Privacy notice',
           href: 'https://www.payments.service.gov.uk/privacy'
+        },
+        {
+          text: 'reCAPTCHA notice',
+          href: 'https://www.payments.service.gov.uk/recaptcha-notice'
+        },
+        {
+          text: 'Cookies',
+          href: 'https://www.payments.service.gov.uk/cookies'
         },
         {
           text: 'Accessibility statement',


### PR DESCRIPTION
Add footer links to reCAPTHCA notice and cookie policy.

Rename privacy policy link to match page title and payments page footer.