### PR TITLE
Revert "Bump envfile from 5.2.0 to 6.17.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2199,6 +2199,16 @@
       "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
       "dev": true
     },
+    "ambi": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ambi/-/ambi-7.3.0.tgz",
+      "integrity": "sha512-RwJuvpa3uqyPozisbrvTB3QZfcYRmzcvxx7UIpa6RiORUNuSAORq5CFr0Mj5plFMFqFsdEXHwv2o4o+ubLQE/Q==",
+      "dev": true,
+      "requires": {
+        "editions": "^2.3.0",
+        "typechecker": "^7.0.0"
+      }
+    },
     "amdefine": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.0.4.tgz",
@@ -4890,6 +4900,23 @@
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
     },
+    "eachr": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-4.5.0.tgz",
+      "integrity": "sha512-9I664RWp6p8jvcHZIwo7bWaiSaUmA1wNSLKwNZEiaYjqiTARq3cGjyRiIunsopZv4QMmX3T5Hs17QoPAzdYxfg==",
+      "dev": true,
+      "requires": {
+        "typechecker": "^6.2.0"
+      },
+      "dependencies": {
+        "typechecker": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-6.4.0.tgz",
+          "integrity": "sha512-EbOu+9szY13mhl0EsvLXnR+pTCa3gTHQQPLdce72ujcC9fRHXlVFBNXtHeRhgzLxLlKUh4zA9C0tezLDgshf+A==",
+          "dev": true
+        }
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4897,6 +4924,24 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "editions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.0.tgz",
+      "integrity": "sha512-jeXYwHPKbitU1l14dWlsl5Nm+b1Hsm7VX73BsrQ4RVwEcAQQIPFHTZAbVtuIGxZBrpdT2FXd8lbtrNBrzZxIsA==",
+      "dev": true,
+      "requires": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -4995,9 +5040,21 @@
       "integrity": "sha1-QWgTO0K7BcOKNbGuQ5fIKYqzaeA="
     },
     "envfile": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/envfile/-/envfile-6.17.0.tgz",
-      "integrity": "sha512-RnhtVw3auDZeeh5VtaNrbE7s6Kq8BoRtGIzcbMpMsJ+wIpRgs5jiDG4gQjW+vfws5QPlizE57/fUU0Tj6Nrs8A==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/envfile/-/envfile-5.2.0.tgz",
+      "integrity": "sha512-AvFbXqYw/zZCQLSt3KisBTf42nNAgZ9mkewvTfoPtYuBeIld7UMmNvVQewVu4c0w93STUAfyZZf8DS4jD7JTag==",
+      "dev": true,
+      "requires": {
+        "ambi": "^7.3.0",
+        "eachr": "^4.5.0",
+        "editions": "^2.3.0",
+        "typechecker": "^7.0.0"
+      }
+    },
+    "errlop": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
+      "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==",
       "dev": true
     },
     "error": {
@@ -14192,6 +14249,12 @@
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
       }
+    },
+    "typechecker": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-7.0.0.tgz",
+      "integrity": "sha512-ZCrFdtqmB2EaHUOkfdVwCVr43mECsPdzTgEwlWI+GCmPBW2gjVHU2HgXI/ci4nLGbfAIUIWDKSYgseUTh4RBqw==",
+      "dev": true
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "chokidar": "^3.5.2",
     "chokidar-cli": "latest",
     "dotenv": "^10.0.0",
-    "envfile": "^6.17.0",
+    "envfile": "^5.2.0",
     "eslint": "6.8.x",
     "grunt": "1.4.x",
     "grunt-babel": "^8.0.0",


### PR DESCRIPTION
Reverts alphagov/pay-products-ui#1414

[Build](https://build.ci.pymnt.uk/job/pay-products-ui/job/master/150/console) fails with 
```
12:23:28  (node:72) DeprecationWarning: Configuration via mocha.opts is DEPRECATED and will be removed from a future version of Mocha. Use RC files or package.json instead.
12:23:28  (node:72) UnhandledPromiseRejectionWarning: TypeError: Cannot convert undefined or null to object
12:23:28      at Function.keys (<anonymous>)
12:23:28      at Object.help (/app/node_modules/mocha/node_modules/yargs/lib/usage.js:240:22)
12:23:28      at Object.self.showHelp (/app/node_modules/mocha/node_modules/yargs/lib/usage.js:432:15)
12:23:28      at Array.<anonymous> (/app/node_modules/mocha/lib/cli/cli.js:53:13)
12:23:28      at Object.fail (/app/node_modules/mocha/node_modules/yargs/lib/usage.js:41:17)
12:23:28      at /app/node_modules/mocha/node_modules/yargs/lib/command.js:246:36
12:23:28      at processTicksAndRejections (internal/process/task_queues.js:97:5)
12:23:28  (node:72) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
12:23:28  (node:72) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```