### PR TITLE
pp-7475 add labels to GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,13 @@ updates:
     versions:
     - ">= 16.a"
     - "< 17"
-- package-ecosystem: "github-actions"
+- package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: "daily"
+    interval: daily
     time: "03:00"
+  open-pull-requests-limit: 10
+  labels:
+  - dependencies
+  - govuk-pay
+  - github_actions


### PR DESCRIPTION
## WHAT
Update dependabot config to correctly label github actions