### PR TITLE
PP-8940 New payments link - reference page

### DIFF
--- a/app/paths.js
+++ b/app/paths.js
@@ -18,6 +18,7 @@ module.exports = {
     product: '/pay/:productExternalId',
     amount: '/pay/:productExternalId/amount',
     reference: '/pay/:productExternalId/reference',
+    referenceConfirm: '/pay/:productExternalId/reference/confirm',
     confirm: '/pay/:productExternalId/confirm'
   },
   demoPayment: {

--- a/app/payment-link-v2/amount/get-index.controller.js
+++ b/app/payment-link-v2/amount/get-index.controller.js
@@ -5,7 +5,7 @@ const { getSessionVariable } = require('../../utils/cookie')
 const { NotFoundError } = require('../../errors')
 const getBackLinkUrl = require('./get-back-link-url')
 
-module.exports = (req, res, next) => {
+module.exports = function getAmountPage (req, res, next) {
   const product = req.product
 
   const data = {

--- a/app/payment-link-v2/amount/post-index.controller.js
+++ b/app/payment-link-v2/amount/post-index.controller.js
@@ -22,7 +22,7 @@ function validateAmountFormValue (amount, res) {
   return errors
 }
 
-module.exports = async function (req, res, next) {
+module.exports = function postAmountPage (req, res, next) {
   const paymentAmount = lodash.get(req.body, PAYMENT_AMOUNT, '')
   const errors = validateAmountFormValue(paymentAmount, res)
 

--- a/app/payment-link-v2/amount/post-index.controller.test.js
+++ b/app/payment-link-v2/amount/post-index.controller.test.js
@@ -53,12 +53,10 @@ describe('Amount Page - POST controller', () => {
 
     controller(req, res)
 
-    expect(mockCookie.setSessionVariable.called).to.equal(true)
-    expect(mockCookie.setSessionVariable.args[0]).to.include(req)
-    expect(mockCookie.setSessionVariable.args[0]).to.include('paymentAmount')
-    expect(mockCookie.setSessionVariable.args[0]).to.include('1000')
+    sinon.assert.called(mockCookie.setSessionVariable)
+    sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'paymentAmount', '1000')
 
-    expect(res.redirect.called).to.equal(true)
+    sinon.assert.called(res.redirect)
     expect(res.redirect.args[0][0]).to.equal('/pay/an-external-id/confirm')
   })
 
@@ -80,16 +78,14 @@ describe('Amount Page - POST controller', () => {
 
     controller(req, res)
 
-    expect(responseSpy.called).to.equal(true)
-    expect(mockResponses.response.args[0]).to.include(req)
-    expect(mockResponses.response.args[0]).to.include(res)
-    expect(mockResponses.response.args[0]).to.include('amount/amount')
+    sinon.assert.called(responseSpy)
+    sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
     const pageData = mockResponses.response.args[0][3]
     expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
 
-    expect(res.locals.__p.called).to.equal(true)
-    expect(res.locals.__p.args[0]).to.include('paymentLinksV2.fieldValidation.enterAnAmountInPounds')
+    sinon.assert.called(res.locals.__p)
+    sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.enterAnAmountInPounds')
   })
 
   it('when an invalid amount is entered and an amount is already saved to the session, it should display an error' +
@@ -113,15 +109,13 @@ describe('Amount Page - POST controller', () => {
 
     controller(req, res)
 
-    expect(responseSpy.called).to.equal(true)
-    expect(mockResponses.response.args[0]).to.include(req)
-    expect(mockResponses.response.args[0]).to.include(res)
-    expect(mockResponses.response.args[0]).to.include('amount/amount')
+    sinon.assert.called(responseSpy)
+    sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
     const pageData = mockResponses.response.args[0][3]
     expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
 
-    expect(res.locals.__p.called).to.equal(true)
-    expect(res.locals.__p.args[0]).to.include('paymentLinksV2.fieldValidation.enterAnAmountInTheCorrectFormat')
+    sinon.assert.called(res.locals.__p)
+    sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.enterAnAmountInTheCorrectFormat')
   })
 })

--- a/app/payment-link-v2/reference/get-back-link-url.js
+++ b/app/payment-link-v2/reference/get-back-link-url.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const replaceParamsInPath = require('../../utils/replace-params-in-path')
+const { paymentLinksV2 } = require('../../paths')
+
+module.exports = function getBackLinkUrl (reference, product) {
+  if (reference) {
+    return replaceParamsInPath(paymentLinksV2.confirm, product.externalId)
+  } else {
+    return replaceParamsInPath(paymentLinksV2.product, product.externalId)
+  }
+}

--- a/app/payment-link-v2/reference/get-back-link-url.test.js
+++ b/app/payment-link-v2/reference/get-back-link-url.test.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { expect } = require('chai')
+
+const getBackLinkUrl = require('./get-back-link-url')
+
+describe('getBackLinkUrl', () => {
+  it('when there is an `reference`, then it should return the `confirm` page URL', () => {
+    const reference = 'a-valid-reference'
+
+    const product = {
+      externalId: 123,
+      reference_enabled: true
+    }
+
+    const url = getBackLinkUrl(reference, product)
+
+    expect(url).to.equal('/pay/123/confirm')
+  })
+
+  it('when there is NO `reference`, then it should return the `product` page URL', () => {
+    const reference = 0
+
+    const product = {
+      externalId: 123,
+      reference_enabled: true
+    }
+
+    const url = getBackLinkUrl(reference, product)
+
+    expect(url).to.equal('/pay/123')
+  })
+})

--- a/app/payment-link-v2/reference/get-index.controller.js
+++ b/app/payment-link-v2/reference/get-index.controller.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const { response } = require('../../utils/response')
+const { getSessionVariable } = require('../../utils/cookie')
+const { NotFoundError } = require('../../errors')
+const getBackLinkUrl = require('./get-back-link-url')
+
+module.exports = function getReferencePage (req, res, next) {
+  const product = req.product
+
+  const data = {
+    productExternalId: product.externalId,
+    productName: product.name,
+    paymentReferenceLabel: product.reference_label,
+    paymentReferenceHint: product.reference_hint
+  }
+
+  if (!product.reference_enabled) {
+    return next(new NotFoundError('Attempted to access reference page with a product that auto-generates references.'))
+  }
+
+  const sessionReferenceNumber = getSessionVariable(req, 'referenceNumber')
+
+  data.backLinkHref = getBackLinkUrl(sessionReferenceNumber, product)
+
+  if (sessionReferenceNumber) {
+    data.referenceNumber = sessionReferenceNumber
+  }
+
+  return response(req, res, 'reference/reference', data)
+}

--- a/app/payment-link-v2/reference/get-index.controller.test.js
+++ b/app/payment-link-v2/reference/get-index.controller.test.js
@@ -17,7 +17,7 @@ const mockResponses = {
 
 let req, res
 
-describe('Amount Page - GET controller', () => {
+describe('Reference Page - GET controller', () => {
   const mockCookie = {
     getSessionVariable: sinon.stub()
   }
@@ -41,8 +41,9 @@ describe('Amount Page - GET controller', () => {
       price: null
     }).getPlain())
 
-    it('when the amount is NOT in the session, then it should display the amount page', () => {
-      mockCookie.getSessionVariable.withArgs(req, 'amount').returns(null)
+    it('when the reference is NOT in the session, then it should display the reference page ' +
+      'and set the back link to the PRODUCT page', () => {
+      mockCookie.getSessionVariable.withArgs(req, 'referenceNumber').returns(null)
 
       req = {
         correlationId: '123',
@@ -53,61 +54,15 @@ describe('Amount Page - GET controller', () => {
       controller(req, res)
 
       sinon.assert.called(responseSpy)
-      sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
-
-      const pageData = mockResponses.response.args[0][3]
-      expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
-    })
-
-    it('when the amount is in the session, then it should display that amount to 2 decimal points' +
-      'and set the back link to the CONFIRM page', () => {
-      mockCookie.getSessionVariable.returns(1000)
-
-      req = {
-        correlationId: '123',
-        product,
-        service
-      }
-      res = {}
-      controller(req, res)
-
-      sinon.assert.called(responseSpy)
-      sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
-
-      const pageData = mockResponses.response.args[0][3]
-      expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
-      expect(pageData.productAmount).to.equal('10.00')
-    })
-  })
-
-  describe('when product.reference_enabled=false', () => {
-    const product = new Product(productFixtures.validCreateProductResponse({
-      type: 'ADHOC',
-      reference_enabled: false,
-      price: null
-    }).getPlain())
-
-    it('when the amount is NOT in the session, then it should display the amount page', () => {
-      mockCookie.getSessionVariable.withArgs(req, 'amount').onFirstCall().returns(null)
-
-      req = {
-        correlationId: '123',
-        product,
-        service
-      }
-      res = {}
-      controller(req, res)
-
-      sinon.assert.called(responseSpy)
-      sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
+      sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
 
       const pageData = mockResponses.response.args[0][3]
       expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
     })
 
-    it('when the amount is in the session, then it should display that amount to 2 decimal points' +
+    it('when the reference is in the session, then it should display the reference page ' +
       'and set the back link to the CONFIRM page', () => {
-      mockCookie.getSessionVariable.returns(1000)
+      mockCookie.getSessionVariable.returns('refrence test value')
 
       req = {
         correlationId: '123',
@@ -118,15 +73,15 @@ describe('Amount Page - GET controller', () => {
       controller(req, res)
 
       sinon.assert.called(responseSpy)
-      sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
+      sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
 
       const pageData = mockResponses.response.args[0][3]
       expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
-      expect(pageData.productAmount).to.equal('10.00')
+      expect(pageData.referenceNumber).to.equal('refrence test value')
     })
   })
 
-  describe('when there is already an amount in the product', () => {
+  describe('when there is already an reference in the product', () => {
     const product = new Product(productFixtures.validCreateProductResponse({
       type: 'ADHOC',
       reference_enabled: false,
@@ -143,9 +98,9 @@ describe('Amount Page - GET controller', () => {
       const next = sinon.spy()
       controller(req, res, next)
 
-      sinon.assert.called(next)
       const expectedError = sinon.match.instanceOf(NotFoundError)
-        .and(sinon.match.has('message', 'Attempted to access amount page with a product that already has a price.'))
+        .and(sinon.match.has('message', 'Attempted to access reference page with a product that auto-generates references.'))
+
       sinon.assert.calledWith(next, expectedError)
     })
   })

--- a/app/payment-link-v2/reference/index.js
+++ b/app/payment-link-v2/reference/index.js
@@ -1,0 +1,4 @@
+'use strict'
+
+module.exports.index = require('./get-index.controller')
+module.exports.postIndex = require('./post-index.controller')

--- a/app/payment-link-v2/reference/is-a-potential-pan.js
+++ b/app/payment-link-v2/reference/is-a-potential-pan.js
@@ -1,0 +1,15 @@
+'use strict'
+
+const Luhn = require('luhn-js')
+
+module.exports = function isAPotentialPAN (value) {
+  const referenceWithoutSpaceAndHyphen = value.replace(/[\s-]/g, '')
+
+  const NUMBERS_ONLY = /^\d+$/
+  if (NUMBERS_ONLY.test(referenceWithoutSpaceAndHyphen) &&
+      referenceWithoutSpaceAndHyphen.length >= 12 && referenceWithoutSpaceAndHyphen.length <= 19) {
+    return Luhn.isValid(referenceWithoutSpaceAndHyphen)
+  }
+
+  return false
+}

--- a/app/payment-link-v2/reference/is-a-potential-pan.test.js
+++ b/app/payment-link-v2/reference/is-a-potential-pan.test.js
@@ -1,0 +1,28 @@
+'use strict'
+
+const isAPotentialPAN = require('./is-a-potential-pan')
+const { expect } = require('chai')
+
+describe('Is A Potential card number', () => {
+  it('should return true if reference passes luhn check', () => {
+    expect(isAPotentialPAN('4242424242424242')).to.equal(true)
+  })
+  it('should return true if reference has characters [- or space] and passes luhn check', () => {
+    expect(isAPotentialPAN('4242 4242 4242-42-42')).to.equal(true)
+  })
+  it('should return false if reference is less than 12 digits', () => {
+    expect(isAPotentialPAN('42424242424')).to.equal(false)
+  })
+  it('should return false if reference has more than 19 digits', () => {
+    expect(isAPotentialPAN('4242 4242 4242 4242 4242 4242')).to.equal(false)
+  })
+  it('should return false if reference fails luhn check', () => {
+    expect(isAPotentialPAN('42424242424211')).to.equal(false)
+  })
+  it('should return false if reference has characters [- or space] and but fails luhn check', () => {
+    expect(isAPotentialPAN('4242-4242-4242-11')).to.equal(false)
+  })
+  it('should return false for reference with characters', () => {
+    expect(isAPotentialPAN('REF123456')).to.equal(false)
+  })
+})

--- a/app/payment-link-v2/reference/post-index.controller.js
+++ b/app/payment-link-v2/reference/post-index.controller.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const lodash = require('lodash')
+
+const { response } = require('../../utils/response')
+const { getSessionVariable } = require('../../utils/cookie')
+const paths = require('../../paths')
+const { validateReference } = require('../../utils/validation/form-validations')
+const replaceParamsInPath = require('../../utils/replace-params-in-path')
+const { setSessionVariable } = require('../../utils/cookie')
+const getBackLinkUrl = require('./get-back-link-url')
+const isAPotentialPan = require('./is-a-potential-pan')
+
+const PAYMENT_REFERENCE = 'payment-reference'
+
+function validateReferenceFormValue (reference, res) {
+  const errors = {}
+  const referenceValidationResult = validateReference(reference)
+  if (!referenceValidationResult.valid) {
+    errors[PAYMENT_REFERENCE] = res.locals.__p(referenceValidationResult.messageKey)
+  }
+
+  return errors
+}
+
+function getNextPageUrl (productPrice, sessionAmount, reference) {
+  if (isAPotentialPan(reference)) {
+    return paths.paymentLinksV2.referenceConfirm
+  } else if (productPrice || sessionAmount) {
+    return paths.paymentLinksV2.confirm
+  } else {
+    return paths.paymentLinksV2.amount
+  }
+}
+
+module.exports = function postReferencePage (req, res, next) {
+  const paymentReference = lodash.get(req.body, PAYMENT_REFERENCE, '')
+  const errors = validateReferenceFormValue(paymentReference, res)
+
+  const product = req.product
+
+  const sessionRefererence = getSessionVariable(req, 'referenceNumber')
+  const sessionAmount = getSessionVariable(req, 'amount')
+
+  const backLinkHref = getBackLinkUrl(sessionRefererence, product)
+
+  const data = {
+    productExternalId: product.externalId,
+    productName: product.name,
+    backLinkHref: backLinkHref
+  }
+
+  if (!lodash.isEmpty(errors)) {
+    data.errors = errors
+    data.reference = paymentReference
+
+    return response(req, res, 'reference/reference', data)
+  }
+
+  setSessionVariable(req, 'referenceNumber', paymentReference)
+
+  return res.redirect(replaceParamsInPath(getNextPageUrl(product.price, sessionAmount, paymentReference), product.externalId))
+}

--- a/app/payment-link-v2/reference/post-index.controller.test.js
+++ b/app/payment-link-v2/reference/post-index.controller.test.js
@@ -1,0 +1,233 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { expect } = require('chai')
+
+const productFixtures = require('../../../test/fixtures/product.fixtures')
+const responseSpy = sinon.spy()
+const Product = require('../../models/Product.class')
+
+const mockResponses = {
+  response: responseSpy
+}
+
+let req, res
+
+describe('Reference Page - POST controller', () => {
+  const mockCookie = {
+    getSessionVariable: sinon.stub(),
+    setSessionVariable: sinon.stub()
+  }
+
+  const controller = proxyquire('./post-index.controller', {
+    '../../utils/response': mockResponses,
+    '../../utils/cookie': mockCookie
+  })
+
+  describe('when the product has no price', () => {
+    const product = new Product(productFixtures.validCreateProductResponse({
+      type: 'ADHOC',
+      reference_enabled: true,
+      price: null
+    }).getPlain())
+
+    beforeEach(() => {
+      mockCookie.getSessionVariable.reset()
+      mockCookie.setSessionVariable.reset()
+      responseSpy.resetHistory()
+    })
+
+    it('when a valid reference is entered, it should save the reference to the session and ' +
+      'redirect to the amount page', () => {
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-reference': 'valid reference'
+        }
+      }
+
+      res = {
+        redirect: sinon.spy()
+      }
+
+      controller(req, res)
+
+      sinon.assert.called(mockCookie.setSessionVariable)
+      sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', 'valid reference')
+
+      sinon.assert.called(res.redirect)
+      sinon.assert.calledWith(res.redirect, '/pay/an-external-id/amount')
+    })
+
+    it('when an valid reference is entered and an AMOUNT is already saved to the session, it should  ' +
+    'redirect to the CONFIRM page', () => {
+      mockCookie.getSessionVariable.withArgs(req, 'amount').returns(1000)
+
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-reference': 'valid reference'
+        }
+      }
+
+      res = {
+        redirect: sinon.spy()
+      }
+
+      controller(req, res)
+
+      sinon.assert.called(mockCookie.setSessionVariable)
+      sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', 'valid reference')
+
+      sinon.assert.called(res.redirect)
+      sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
+    })
+
+    it('when reference is a potential card number, it should  ' +
+    'redirect to the REFERENCE CONFIRM page', () => {
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-reference': '4242424242424242'
+        }
+      }
+
+      res = {
+        redirect: sinon.spy()
+      }
+
+      controller(req, res)
+
+      sinon.assert.called(mockCookie.setSessionVariable)
+      sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', '4242424242424242')
+
+      sinon.assert.called(res.redirect)
+      sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference/confirm')
+    })
+
+    it('when reference is a potential card number and there is an amount in the session, it should  ' +
+    'redirect to the REFERENCE CONFIRM page', () => {
+      mockCookie.getSessionVariable.withArgs(req, 'amount').returns(1000)
+
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-reference': '4242424242424242'
+        }
+      }
+
+      res = {
+        redirect: sinon.spy()
+      }
+
+      controller(req, res)
+
+      sinon.assert.called(mockCookie.setSessionVariable)
+      sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', '4242424242424242')
+
+      sinon.assert.called(res.redirect)
+      sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference/confirm')
+    })
+
+    it('when an empty reference is entered, it should display an error message and the back link correctly', () => {
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-reference': ''
+        }
+      }
+
+      res = {
+        redirect: sinon.spy(),
+        locals: {
+          __p: sinon.spy()
+        }
+      }
+
+      controller(req, res)
+
+      sinon.assert.called(responseSpy)
+      sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
+
+      const pageData = mockResponses.response.args[0][3]
+      expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
+
+      sinon.assert.called(res.locals.__p)
+      sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.enterAReference')
+    })
+
+    it('when an invalid reference is entered and a reference is already saved to the session, it should display an error ' +
+    'message and set the back link to the CONFIRM page', () => {
+      mockCookie.getSessionVariable.returns('a valid refererence')
+
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-reference': 'reference with invalid characters <>'
+        }
+      }
+
+      res = {
+        redirect: sinon.spy(),
+        locals: {
+          __p: sinon.spy()
+        }
+      }
+
+      controller(req, res)
+
+      sinon.assert.called(responseSpy)
+      sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
+
+      const pageData = mockResponses.response.args[0][3]
+      expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
+
+      sinon.assert.called(res.locals.__p)
+      sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.referenceCantUseInvalidChars')
+    })
+  })
+
+  describe('when the product has a price', () => {
+    const product = new Product(productFixtures.validCreateProductResponse({
+      type: 'ADHOC',
+      reference_enabled: true,
+      price: 1000
+    }).getPlain())
+
+    beforeEach(() => {
+      mockCookie.getSessionVariable.reset()
+      mockCookie.setSessionVariable.reset()
+      responseSpy.resetHistory()
+    })
+
+    it('when a valid reference is entered, it should save the reference to the session and ' +
+      'redirect to the confirm page', () => {
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-reference': 'valid reference'
+        }
+      }
+
+      res = {
+        redirect: sinon.spy()
+      }
+
+      controller(req, res)
+
+      sinon.assert.called(mockCookie.setSessionVariable)
+      sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', 'valid reference')
+
+      sinon.assert.called(res.redirect)
+      sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
+    })
+  })
+})

--- a/app/payment-link-v2/reference/reference.njk
+++ b/app/payment-link-v2/reference/reference.njk
@@ -1,11 +1,11 @@
-{% extends "../../views/layout-payment-links-v2.njk" %}
+{% extends "../../views/layout.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../views/macros/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
-  {{ __p('paymentLinksV2.amount.enterAmountToPay') }} - {{ productName }}
+  {{ __p('paymentLinksV2.reference.pleaseEnterYour') }} {{product.reference_label}}  - {{ productName }}
 {% endblock %}
 
 {% block contentBody %}
@@ -19,7 +19,7 @@
     {{ errorSummary ({
       errors: errors,
       hrefs: {
-        'payment-amount': '#payment-amount'
+        'payment-reference': '#payment-reference'
       }
     }) }}
 
@@ -27,19 +27,19 @@
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({
-        id: "payment-amount",
-        name: "payment-amount",
-        errorMessage: { text: errors['payment-amount']} if errors['payment-amount'] else false,
+        id: "payment-reference",
+        name: "payment-reference",
+        errorMessage: { text: errors['payment-reference']} if errors['payment-reference'] else false,
         label: {
-          text: __p('paymentLinksV2.amount.enterAmountToPay'),
+          text: __p('paymentLinksV2.reference.pleaseEnterYour') + ' ' + product.reference_label,
           classes: "govuk-label--l",
           isPageHeading: true
         },
-        value: amount,
-        prefix: {
-          text: "£"
+        hint: {
+          text: product.reference_hint
         },
-        classes: "govuk-input--width-5",
+        value: reference,
+        classes: "govuk-input--width-20",
         spellcheck: false
       }) }}
       

--- a/app/routes.js
+++ b/app/routes.js
@@ -15,6 +15,7 @@ const failedCtrl = require('./controllers/demo-payment/payment-failed.controller
 const successCtrl = require('./controllers/demo-payment/payment-success.controller')
 const adhocPaymentCtrl = require('./controllers/adhoc-payment')
 const amountCtrl = require('./payment-link-v2/amount')
+const referenceCtrl = require('./payment-link-v2/reference')
 const productReferenceCtrl = require('./controllers/product-reference')
 
 // Middleware
@@ -67,6 +68,10 @@ module.exports.bind = function (app) {
   // payment links amount
   app.get(paymentLinksV2.amount, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, amountCtrl.index)
   app.post(paymentLinksV2.amount, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, amountCtrl.postIndex)
+
+  // payment links reference
+  app.get(paymentLinksV2.reference, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, referenceCtrl.index)
+  app.post(paymentLinksV2.reference, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, referenceCtrl.postIndex)
 
   // security.txt — https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html
   const securitytxt = 'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'

--- a/app/utils/validation/form-validations.js
+++ b/app/utils/validation/form-validations.js
@@ -6,7 +6,10 @@ const MAX_AMOUNT = 100000
 const validationMessageKeys = {
   enterAnAmountInPounds: 'paymentLinksV2.fieldValidation.enterAnAmountInPounds',
   enterAnAmountInTheCorrectFormat: 'paymentLinksV2.fieldValidation.enterAnAmountInTheCorrectFormat',
-  enterAnAmountUnderMaxAmount: 'paymentLinksV2.fieldValidation.enterAnAmountUnderMaxAmount'
+  enterAnAmountUnderMaxAmount: 'paymentLinksV2.fieldValidation.enterAnAmountUnderMaxAmount',
+  enterAReference: 'paymentLinksV2.fieldValidation.enterAReference',
+  referenceMustBeLessThanOrEqual50Chars: 'paymentLinksV2.fieldValidation.referenceMustBeLessThanOrEqual50Chars',
+  referenceCantUseInvalidChars: 'paymentLinksV2.fieldValidation.referenceCantUseInvalidChars'
 }
 
 exports.validationErrors = validationMessageKeys
@@ -23,7 +26,7 @@ function notValidReturnObject (messageKey) {
   }
 }
 
-function isEmpty (value) {
+function isEmptyAmount (value) {
   if (value === '') {
     return validationMessageKeys.enterAnAmountInPounds
   } else {
@@ -46,10 +49,34 @@ function isAboveMaxAmount (value) {
   return false
 }
 
+function isEmptyReference (value) {
+  if (value === '') {
+    return validationMessageKeys.enterAReference
+  } else {
+    return false
+  }
+}
+
+function isReferenceTooLong (value) {
+  if (value.trim().length > 50) {
+    return validationMessageKeys.referenceMustBeLessThanOrEqual50Chars
+  } else {
+    return false
+  }
+}
+
+function isReferenceNaxsiSafe (value) {
+  if (/[<>;:`()"'=|,~[\]]+/g.test(value)) {
+    return validationMessageKeys.referenceCantUseInvalidChars
+  } else {
+    return false
+  }
+}
+
 function validateAmount (amount) {
-  const isEmptyErrorMessageKey = isEmpty(amount)
-  if (isEmptyErrorMessageKey) {
-    return notValidReturnObject(isEmptyErrorMessageKey)
+  const isEmptyAmountErrorMessageKey = isEmptyAmount(amount)
+  if (isEmptyAmountErrorMessageKey) {
+    return notValidReturnObject(isEmptyAmountErrorMessageKey)
   }
 
   const isNotCurrencyErrorMessageKey = isNotCurrency(amount)
@@ -65,6 +92,26 @@ function validateAmount (amount) {
   return validReturnObject
 }
 
+function validateReference (reference) {
+  const isEmptyReferenceErrorMessageKey = isEmptyReference(reference)
+  if (isEmptyReferenceErrorMessageKey) {
+    return notValidReturnObject(isEmptyReferenceErrorMessageKey)
+  }
+
+  const isReferenceTooLongErrorMessageKey = isReferenceTooLong(reference)
+  if (isReferenceTooLongErrorMessageKey) {
+    return notValidReturnObject(isReferenceTooLongErrorMessageKey)
+  }
+
+  const isReferenceNaxsiSafeErrorMessageKey = isReferenceNaxsiSafe(reference)
+  if (isReferenceNaxsiSafeErrorMessageKey) {
+    return notValidReturnObject(isReferenceNaxsiSafeErrorMessageKey)
+  }
+
+  return validReturnObject
+}
+
 module.exports = {
-  validateAmount
+  validateAmount,
+  validateReference
 }

--- a/app/utils/validation/form-validations.test.js
+++ b/app/utils/validation/form-validations.test.js
@@ -31,4 +31,31 @@ describe('Server side form validations', () => {
       })
     })
   })
+
+  describe('reference validation', () => {
+    it('when valid reference is entered, should return valid=true', () => {
+      expect(validations.validateReference('test reference').valid).to.be.true // eslint-disable-line
+    })
+
+    it('when no amount entered, should return valid=false and the correct error message key', () => {
+      expect(validations.validateReference('')).to.deep.equal({
+        valid: false,
+        messageKey: 'paymentLinksV2.fieldValidation.enterAReference'
+      })
+    })
+
+    it('when a reference is too long, should return valid=false and correct error message key', () => {
+      expect(validations.validateReference('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')).to.deep.equal({
+        valid: false,
+        messageKey: 'paymentLinksV2.fieldValidation.referenceMustBeLessThanOrEqual50Chars'
+      })
+    })
+
+    it('when a reference is entered that is not Naxsi safe, should return valid=false and correct error message key', () => {
+      expect(validations.validateAmount('>')).to.deep.equal({
+        valid: false,
+        messageKey: 'paymentLinksV2.fieldValidation.enterAnAmountInTheCorrectFormat'
+      })
+    })
+  })
 })

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -56,10 +56,16 @@
     "amount": {
       "enterAmountToPay": "TODO convert to Welsh - Enter amount to pay" 
     },
+    "reference": { 
+      "pleaseEnterYour": "TODO convert to Welsh - Please enter your"
+    },
     "fieldValidation": {
       "enterAnAmountInPounds": "TODO convert to Welsh - Enter an amount in pounds",
       "enterAnAmountInTheCorrectFormat": "TODO convert to Welsh - Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”",
-      "enterAnAmountUnderMaxAmount": "TODO convert to Welsh - Enter an amount that is £100,000 or under"
+      "enterAnAmountUnderMaxAmount": "TODO convert to Welsh - Enter an amount that is £100,000 or under",
+      "enterAReference": "TODO convert to Welsh - Enter a reference",
+      "referenceMustBeLessThanOrEqual50Chars": "TODO convert to Welsh - reference must be less than or equal to 50 characters",
+      "referenceCantUseInvalidChars": "TODO convert to Welsh - Reference can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
     }
   } 
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -54,12 +54,18 @@
   },
   "paymentLinksV2": {
     "amount": {
-      "enterAmountToPay": "Enter amount to pay" 
+      "enterAmountToPay": "Enter amount to pay"
+    },
+    "reference": { 
+      "pleaseEnterYour": "Please enter your"
     },
     "fieldValidation": {
       "enterAnAmountInPounds": "Enter an amount in pounds",
       "enterAnAmountInTheCorrectFormat": "Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”",
-      "enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or under"
+      "enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or under",
+      "enterAReference": "Enter a reference",
+      "referenceMustBeLessThanOrEqual50Chars": "reference must be less than or equal to 50 characters",
+      "referenceCantUseInvalidChars": "Reference can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
     }
   }
 }


### PR DESCRIPTION
- Add new code for the new Payment Links reference page:
  - Add new controllers.
  - Add new Nunjucks page.
  - Add new form validations.
  - Create new `get-back-link` function - works out the back link for the reference page.
  - If the reference is a potential PAN number, then redirect to the `reference/confirm`
  - Extract the `isAPotentialPanNumber` function into it's own function.