### PR TITLE
PP-8940 Clean up tests for new reference and amount pages

### DIFF
--- a/app/payment-link-v2/amount/get-index.controller.test.js
+++ b/app/payment-link-v2/amount/get-index.controller.test.js
@@ -52,7 +52,6 @@ describe('Amount Page - GET controller', () => {
       res = {}
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
       const pageData = mockResponses.response.args[0][3]
@@ -71,7 +70,6 @@ describe('Amount Page - GET controller', () => {
       res = {}
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
       const pageData = mockResponses.response.args[0][3]
@@ -98,7 +96,6 @@ describe('Amount Page - GET controller', () => {
       res = {}
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
       const pageData = mockResponses.response.args[0][3]
@@ -117,7 +114,6 @@ describe('Amount Page - GET controller', () => {
       res = {}
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
       const pageData = mockResponses.response.args[0][3]
@@ -143,7 +139,6 @@ describe('Amount Page - GET controller', () => {
       const next = sinon.spy()
       controller(req, res, next)
 
-      sinon.assert.called(next)
       const expectedError = sinon.match.instanceOf(NotFoundError)
         .and(sinon.match.has('message', 'Attempted to access amount page with a product that already has a price.'))
       sinon.assert.calledWith(next, expectedError)

--- a/app/payment-link-v2/amount/post-index.controller.test.js
+++ b/app/payment-link-v2/amount/post-index.controller.test.js
@@ -53,11 +53,8 @@ describe('Amount Page - POST controller', () => {
 
     controller(req, res)
 
-    sinon.assert.called(mockCookie.setSessionVariable)
     sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'paymentAmount', '1000')
-
-    sinon.assert.called(res.redirect)
-    expect(res.redirect.args[0][0]).to.equal('/pay/an-external-id/confirm')
+    sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
   })
 
   it('when an empty amount is entered, it should display an error message and the back link correctly', () => {
@@ -78,13 +75,11 @@ describe('Amount Page - POST controller', () => {
 
     controller(req, res)
 
-    sinon.assert.called(responseSpy)
     sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
     const pageData = mockResponses.response.args[0][3]
     expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
 
-    sinon.assert.called(res.locals.__p)
     sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.enterAnAmountInPounds')
   })
 
@@ -109,13 +104,11 @@ describe('Amount Page - POST controller', () => {
 
     controller(req, res)
 
-    sinon.assert.called(responseSpy)
     sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
 
     const pageData = mockResponses.response.args[0][3]
     expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
 
-    sinon.assert.called(res.locals.__p)
     sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.enterAnAmountInTheCorrectFormat')
   })
 })

--- a/app/payment-link-v2/reference/get-index.controller.test.js
+++ b/app/payment-link-v2/reference/get-index.controller.test.js
@@ -53,7 +53,6 @@ describe('Reference Page - GET controller', () => {
       res = {}
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
 
       const pageData = mockResponses.response.args[0][3]
@@ -72,7 +71,6 @@ describe('Reference Page - GET controller', () => {
       res = {}
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
 
       const pageData = mockResponses.response.args[0][3]

--- a/app/payment-link-v2/reference/post-index.controller.test.js
+++ b/app/payment-link-v2/reference/post-index.controller.test.js
@@ -54,10 +54,7 @@ describe('Reference Page - POST controller', () => {
 
       controller(req, res)
 
-      sinon.assert.called(mockCookie.setSessionVariable)
       sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', 'valid reference')
-
-      sinon.assert.called(res.redirect)
       sinon.assert.calledWith(res.redirect, '/pay/an-external-id/amount')
     })
 
@@ -79,10 +76,7 @@ describe('Reference Page - POST controller', () => {
 
       controller(req, res)
 
-      sinon.assert.called(mockCookie.setSessionVariable)
       sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', 'valid reference')
-
-      sinon.assert.called(res.redirect)
       sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
     })
 
@@ -102,10 +96,7 @@ describe('Reference Page - POST controller', () => {
 
       controller(req, res)
 
-      sinon.assert.called(mockCookie.setSessionVariable)
       sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', '4242424242424242')
-
-      sinon.assert.called(res.redirect)
       sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference/confirm')
     })
 
@@ -127,10 +118,7 @@ describe('Reference Page - POST controller', () => {
 
       controller(req, res)
 
-      sinon.assert.called(mockCookie.setSessionVariable)
       sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', '4242424242424242')
-
-      sinon.assert.called(res.redirect)
       sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference/confirm')
     })
 
@@ -152,13 +140,11 @@ describe('Reference Page - POST controller', () => {
 
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
 
       const pageData = mockResponses.response.args[0][3]
       expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
 
-      sinon.assert.called(res.locals.__p)
       sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.enterAReference')
     })
 
@@ -183,13 +169,11 @@ describe('Reference Page - POST controller', () => {
 
       controller(req, res)
 
-      sinon.assert.called(responseSpy)
       sinon.assert.calledWith(responseSpy, req, res, 'reference/reference')
 
       const pageData = mockResponses.response.args[0][3]
       expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
 
-      sinon.assert.called(res.locals.__p)
       sinon.assert.calledWith(res.locals.__p, 'paymentLinksV2.fieldValidation.referenceCantUseInvalidChars')
     })
   })
@@ -223,10 +207,7 @@ describe('Reference Page - POST controller', () => {
 
       controller(req, res)
 
-      sinon.assert.called(mockCookie.setSessionVariable)
       sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'referenceNumber', 'valid reference')
-
-      sinon.assert.called(res.redirect)
       sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
     })
   })


### PR DESCRIPTION
- In the tests, when we use `sinon.assert.called` and then call `sinon.assert.calledWith`.
  - It is unnecessary to use `sinon.assert.called`.
  - As the `sinon.assert.callendWith` does everything that method does as well
    as check the params.
  - So remove all instances of `sinon.assers.called`