### PR TITLE
PP-8940 Reference Page - Fixes as per code review comments

### DIFF
--- a/app/payment-link-v2/amount/amount.controller.js
+++ b/app/payment-link-v2/amount/amount.controller.js
@@ -40,7 +40,7 @@ function getPage (req, res, next) {
   data.backLinkHref = getBackLinkUrl(sessionAmount, product)
 
   if (sessionAmount) {
-    data.productAmount = (sessionAmount / 100).toFixed(2)
+    data.amount = sessionAmount.toFixed(2)
   }
 
   return response(req, res, 'amount/amount', data)
@@ -68,7 +68,7 @@ function postPage (req, res, next) {
     return response(req, res, 'amount/amount', data)
   }
 
-  setSessionVariable(req, 'paymentAmount', paymentAmount)
+  setSessionVariable(req, 'amount', paymentAmount)
 
   return res.redirect(replaceParamsInPath(paths.paymentLinksV2.confirm, product.externalId))
 }

--- a/app/payment-link-v2/amount/amount.controller.test.js
+++ b/app/payment-link-v2/amount/amount.controller.test.js
@@ -66,9 +66,9 @@ describe('Amount Page Controller', () => {
         expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
       })
 
-      it('when the amount is in the session, then it should display that amount to 2 decimal points' +
+      it('when the amount is in the session, then it should display that amount to 2 decimal places ' +
         'and set the back link to the CONFIRM page', () => {
-        mockCookie.getSessionVariable.returns(1000)
+        mockCookie.getSessionVariable.returns(10.50)
 
         req = {
           correlationId: '123',
@@ -82,7 +82,7 @@ describe('Amount Page Controller', () => {
 
         const pageData = mockResponses.response.args[0][3]
         expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
-        expect(pageData.productAmount).to.equal('10.00')
+        expect(pageData.amount).to.equal('10.50')
       })
     })
 
@@ -110,9 +110,9 @@ describe('Amount Page Controller', () => {
         expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
       })
 
-      it('when the amount is in the session, then it should display that amount to 2 decimal points' +
+      it('when the amount is in the session, then it should display that amount to 2 decimal points ' +
         'and set the back link to the CONFIRM page', () => {
-        mockCookie.getSessionVariable.returns(1000)
+        mockCookie.getSessionVariable.returns(10.00)
 
         req = {
           correlationId: '123',
@@ -126,7 +126,7 @@ describe('Amount Page Controller', () => {
 
         const pageData = mockResponses.response.args[0][3]
         expect(pageData.backLinkHref).to.equal('/pay/an-external-id/confirm')
-        expect(pageData.productAmount).to.equal('10.00')
+        expect(pageData.amount).to.equal('10.00')
       })
     })
 
@@ -167,7 +167,7 @@ describe('Amount Page Controller', () => {
         correlationId: '123',
         product,
         body: {
-          'payment-amount': '1000'
+          'payment-amount': '10'
         }
       }
 
@@ -177,7 +177,7 @@ describe('Amount Page Controller', () => {
 
       controller.postPage(req, res)
 
-      sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'paymentAmount', '1000')
+      sinon.assert.calledWith(mockCookie.setSessionVariable, req, 'amount', '10')
       sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
     })
 

--- a/app/payment-link-v2/reference/reference.controller.js
+++ b/app/payment-link-v2/reference/reference.controller.js
@@ -14,11 +14,16 @@ const isAPotentialPan = require('./is-a-potential-pan')
 
 const PAYMENT_REFERENCE = 'payment-reference'
 
-function validateReferenceFormValue (reference, res) {
+function capitaliseFirstLetter (errorMessage) {
+  return errorMessage.charAt(0).toUpperCase() + errorMessage.slice(1)
+}
+
+function validateReferenceFormValue (reference, referenceLabel, res) {
   const errors = {}
   const referenceValidationResult = validateReference(reference)
   if (!referenceValidationResult.valid) {
-    errors[PAYMENT_REFERENCE] = res.locals.__p(referenceValidationResult.messageKey)
+    const errorMessage = res.locals.__p(referenceValidationResult.messageKey).replace('%s', referenceLabel)
+    errors[PAYMENT_REFERENCE] = capitaliseFirstLetter(errorMessage)
   }
 
   return errors
@@ -53,7 +58,7 @@ function getPage (req, res, next) {
   data.backLinkHref = getBackLinkUrl(sessionReferenceNumber, product)
 
   if (sessionReferenceNumber) {
-    data.referenceNumber = sessionReferenceNumber
+    data.reference = sessionReferenceNumber
   }
 
   return response(req, res, 'reference/reference', data)
@@ -61,9 +66,9 @@ function getPage (req, res, next) {
 
 function postPage (req, res, next) {
   const paymentReference = lodash.get(req.body, PAYMENT_REFERENCE, '')
-  const errors = validateReferenceFormValue(paymentReference, res)
-
   const product = req.product
+
+  const errors = validateReferenceFormValue(paymentReference, product.reference_label, res)
 
   const sessionRefererence = getSessionVariable(req, 'referenceNumber')
   const sessionAmount = getSessionVariable(req, 'amount')

--- a/app/payment-link-v2/reference/reference.njk
+++ b/app/payment-link-v2/reference/reference.njk
@@ -1,4 +1,4 @@
-{% extends "../../views/layout.njk" %}
+{% extends "../../views/layout-payment-links-v2.njk" %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
@@ -39,7 +39,7 @@
           text: product.reference_hint
         },
         value: reference,
-        classes: "govuk-input--width-20",
+        classes: "govuk-input--width-21",
         spellcheck: false
       }) }}
       

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -63,9 +63,9 @@
       "enterAnAmountInPounds": "TODO convert to Welsh - Enter an amount in pounds",
       "enterAnAmountInTheCorrectFormat": "TODO convert to Welsh - Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”",
       "enterAnAmountUnderMaxAmount": "TODO convert to Welsh - Enter an amount that is £100,000 or under",
-      "enterAReference": "TODO convert to Welsh - Enter a reference",
-      "referenceMustBeLessThanOrEqual50Chars": "TODO convert to Welsh - reference must be less than or equal to 50 characters",
-      "referenceCantUseInvalidChars": "TODO convert to Welsh - Reference can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
+      "enterAReference": "TODO convert to Welsh - Enter a %s",
+      "referenceMustBeLessThanOrEqual50Chars": "TODO convert to Welsh - %s must be less than or equal to 50 characters",
+      "referenceCantUseInvalidChars": "TODO convert to Welsh - %s can’t contain any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
     }
   } 
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -63,9 +63,9 @@
       "enterAnAmountInPounds": "Enter an amount in pounds",
       "enterAnAmountInTheCorrectFormat": "Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”",
       "enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or under",
-      "enterAReference": "Enter a reference",
-      "referenceMustBeLessThanOrEqual50Chars": "reference must be less than or equal to 50 characters",
-      "referenceCantUseInvalidChars": "Reference can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
+      "enterAReference": "Enter a %s",
+      "referenceMustBeLessThanOrEqual50Chars": "%s must be less than or equal to 50 characters",
+      "referenceCantUseInvalidChars": "%s can’t contain any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
     }
   }
 }


### PR DESCRIPTION
- Update to show `Payment link` name in the header.
- When showing Reference page errors - make sure to reference label
- Capitlise the letter of the reference page errors in the code
  - Easier to do it here rather then CSS, as the Design System `error summary`
    does not allow us to add CSS classes to the individual errors.
- Mobile view - make the input span the entire screen.
- Fix rounding errors when retrieving and displaying the `amount` from the session.
- Fix bugs with saving the amount and reference number to the session
  with the wrong variable names.