### PR TITLE
PP-8970 Adding Cypress test for Reference page + general Cypress cleanup

### DIFF
--- a/app/payment-link-v2/reference/reference.njk
+++ b/app/payment-link-v2/reference/reference.njk
@@ -13,7 +13,10 @@
   <div class="govuk-grid-column-two-thirds">
     {{ govukBackLink({
       text: "Back",
-      href: backLinkHref
+      href: backLinkHref,
+      attributes: {
+        'data-cy': 'back-link'
+      }
     }) }}
 
     {{ errorSummary ({
@@ -29,22 +32,36 @@
       {{ govukInput({
         id: "payment-reference",
         name: "payment-reference",
-        errorMessage: { text: errors['payment-reference']} if errors['payment-reference'] else false,
+        errorMessage: { 
+          text: errors['payment-reference'], 
+          attributes: {
+            'data-cy': 'error-message'
+          }
+        } if errors['payment-reference'] else false,
         label: {
           text: __p('paymentLinksV2.reference.pleaseEnterYour') + ' ' + product.reference_label,
           classes: "govuk-label--l",
-          isPageHeading: true
+          isPageHeading: true,
+          attributes: {
+            'data-cy': 'label'
+          }
         },
         hint: {
           text: product.reference_hint
         },
         value: reference,
         classes: "govuk-input--width-21",
-        spellcheck: false
+        spellcheck: false,
+        attributes: {
+          'data-cy': 'input'
+        }
       }) }}
       
       {{ govukButton({
-        text: __p('buttons.continue')
+        text: __p('buttons.continue'),
+        attributes: {
+          'data-cy': 'button'
+        }
       }) }}
     </form>
   </div>

--- a/app/views/macros/error-summary.njk
+++ b/app/views/macros/error-summary.njk
@@ -12,7 +12,10 @@
   {% if errorList | length %}
     {{ govukErrorSummary({
         titleText: "There is a problem",
-        errorList: errorList
+        errorList: errorList,
+        attributes: {
+          'data-cy': 'error-summary'
+        }
       }) }}
   {% endif %}
 {% endmacro %}

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -65,7 +65,7 @@
       "enterAnAmountUnderMaxAmount": "TODO convert to Welsh - Enter an amount that is £100,000 or under",
       "enterAReference": "TODO convert to Welsh - Enter a valid %s",
       "referenceMustBeLessThanOrEqual50Chars": "TODO convert to Welsh - %s must be less than or equal to 50 characters",
-      "referenceCantUseInvalidChars": "TODO convert to Welsh - %s can’t contain any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
+      "referenceCantUseInvalidChars": "TODO convert to Welsh - %s can’t contain any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]"
     }
   } 
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -65,7 +65,7 @@
       "enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or under",
       "enterAReference": "Enter a valid %s",
       "referenceMustBeLessThanOrEqual50Chars": "%s must be less than or equal to 50 characters",
-      "referenceCantUseInvalidChars": "%s can’t contain any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]"
+      "referenceCantUseInvalidChars": "%s can’t contain any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lint": "./node_modules/.bin/standard --fix",
     "lint-sass": "./node_modules/.bin/sass-lint -v",
     "test-with-coverage": "node ./node_modules/nyc/bin/nyc npm test",
-    "test": "rm -rf ./pacts && ./node_modules/mocha/bin/mocha '!(node_modules)/**/*.test'.js",
+    "test": "rm -rf ./pacts && ./node_modules/mocha/bin/mocha --exclude **/*.cy.test.js '!(node_modules)/**/*.test'.js",
     "snyk-protect": "snyk protect",
     "prepublish": "npm run snyk-protect",
     "publish-pacts": "./bin/publish-pacts.js",

--- a/test/cypress/integration/reference-page/reference.cy.test.js
+++ b/test/cypress/integration/reference-page/reference.cy.test.js
@@ -1,0 +1,74 @@
+'use strict'
+
+const productStubs = require('../../stubs/products-stubs')
+const serviceStubs = require('../../stubs/service-stubs')
+
+const gatewayAccountId = 666
+const productExternalId = 'a-product-id'
+
+describe('Reference page', () => {
+  describe('when the Payment Link has no price', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        productStubs.getProductByExternalIdStub({
+          external_id: productExternalId,
+          reference_enabled: true,
+          reference_label: 'invoice number',
+          type: 'ADHOC'
+        }),
+        serviceStubs.getServiceSuccess({
+          gatewayAccountId: gatewayAccountId,
+          serviceName: {
+            en: 'Test service name'
+          }
+        })
+      ])
+
+      Cypress.Cookies.preserveOnce('session')
+    })
+
+    it('should redirect to the Reference page', () => {
+      cy.visit('/pay/a-product-id/reference')
+
+      cy.get('[data-cy=back-link]').should('have.attr', 'href', '/pay/a-product-id')
+      cy.get('[data-cy=label]').should('contain', 'Please enter your invoice number')
+      cy.get('[data-cy=button]').should('exist')
+    })
+
+    it('when no value entered, should display an error', () => {
+      cy.get('[data-cy=button]').click()
+
+      cy.get('[data-cy=error-summary] a').should('contain', 'Enter a valid invoice number')
+      cy.get('[data-cy=error-summary] a').should('have.attr', 'href', '#payment-reference')
+      cy.get('[data-cy=error-message]').should('contain', 'Enter a valid invoice number')
+    })
+
+    it('when an reference label is entered that is too long, should display an error', () => {
+      cy.get('[data-cy=input]').type('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')
+      cy.get('[data-cy=button]').click()
+
+      cy.get('[data-cy=error-summary] a').should('contain', 'Invoice number must be less than or equal to 50 characters')
+      cy.get('[data-cy=error-summary] a').should('have.attr', 'href', '#payment-reference')
+      cy.get('[data-cy=error-message]').should('contain', 'Invoice number must be less than or equal to 50 characters')
+    })
+
+    it('when an reference label is entered that contains invalid characters, should display an error', () => {
+      cy.get('[data-cy=input]').clear()
+      cy.get('[data-cy=input]').type('reference with invalid characters <>')
+      cy.get('[data-cy=button]').click()
+
+      cy.get('[data-cy=error-summary] a').should('contain', 'Invoice number can’t contain any of the following characters < > ; : ` ( ) " \' = | "," ~ [ ]')
+      cy.get('[data-cy=error-summary] a').should('have.attr', 'href', '#payment-reference')
+      cy.get('[data-cy=error-message]').should('contain', 'Invoice number can’t contain any of the following characters < > ; : ` ( ) " \' = | "," ~ [ ]')
+    })
+
+    it('when a valid label is entered, should then go to the amount page', () => {
+      cy.visit('/pay/a-product-id/reference')
+      cy.get('[data-cy=input]').clear()
+      cy.get('[data-cy=input]').type('a-test-invoice-number')
+      cy.get('[data-cy=button]').click()
+
+      cy.title().should('contain', 'Enter amount to pay - A Product Name')
+    })
+  })
+})


### PR DESCRIPTION
- Add new Cypress test for the Reference page
- Add HTML 'data-cy' attributes - as per Cypress recommendations.
  - These values are used in Cypress tests to select the elements.
- Update locale files so `|` is shown correctly.