### PR TITLE
PP-8942 Confirm page - update page.

### DIFF
--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -1,14 +1,69 @@
 'use strict'
 
 const { response } = require('../../utils/response')
+const { paymentLinksV2 } = require('../../paths')
+const replaceParamsInPath = require('../../utils/replace-params-in-path')
+const { getSessionVariable } = require('../../utils/cookie')
+const { NotFoundError } = require('../../errors')
+
+const HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE = 'reference-value'
+const HIDDEN_FORM_FIELD_ID_AMOUNT = 'amount'
+
+function generateSummaryElement (summaryLabel, summaryValue, changeUrl, hiddenFormFieldId) {
+  return {
+    summaryLabel,
+    summaryValue,
+    changeUrl,
+    hiddenFormFieldId
+  }
+}
+
+function getRightAmountToDisplayAsGbp (sessionAmount, productAmount) {
+  const amountToDisplay = sessionAmount || (productAmount / 100).toFixed(2)
+
+  return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(amountToDisplay)
+}
 
 function getPage (req, res, next) {
   const product = req.product
+
+  const sessionReferenceNumber = getSessionVariable(req, 'referenceNumber')
+  const sessionAmount = getSessionVariable(req, 'amount')
+
+  if (!sessionAmount && !product.price) {
+    return next(new NotFoundError('Attempted to access confirm page without a price in the session or product.'))
+  }
 
   const data = {
     productExternalId: product.externalId,
     productName: product.name
   }
+
+  const summaryElements = []
+
+  if (sessionReferenceNumber) {
+    summaryElements.push(generateSummaryElement(
+      product.reference_label,
+      sessionReferenceNumber,
+      replaceParamsInPath(paymentLinksV2.reference, product.externalId),
+      HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE
+    ))
+  }
+
+  const changeAmountUrl = replaceParamsInPath(paymentLinksV2.amount, product.externalId)
+  const totalToPayText = res.locals.__p('paymentLinksV2.confirm.totalToPay')
+
+  const getAmountToDisplay = getRightAmountToDisplayAsGbp(sessionAmount, product.price)
+
+  summaryElements.push(generateSummaryElement(
+    totalToPayText,
+    getAmountToDisplay,
+    changeAmountUrl,
+    HIDDEN_FORM_FIELD_ID_AMOUNT
+  ))
+
+  data.summaryElements = summaryElements
+  data.confirmPageUrl = replaceParamsInPath(paymentLinksV2.confirm, product.externalId)
 
   return response(req, res, 'confirm/confirm', data)
 }

--- a/app/payment-link-v2/confirm/confirm.controller.test.js
+++ b/app/payment-link-v2/confirm/confirm.controller.test.js
@@ -1,0 +1,193 @@
+'use strict'
+
+const proxyquire = require('proxyquire')
+const sinon = require('sinon')
+const { expect } = require('chai')
+
+const productFixtures = require('../../../test/fixtures/product.fixtures')
+const serviceFixtures = require('../../../test/fixtures/service.fixtures')
+const Service = require('../../models/Service.class')
+const responseSpy = sinon.spy()
+const Product = require('../../models/Product.class')
+const { NotFoundError } = require('../../errors')
+
+const mockResponses = {
+  response: responseSpy
+}
+
+let req, res
+
+describe('Confirm Page Controller', () => {
+  const mockCookie = {
+    getSessionVariable: sinon.stub(),
+    setSessionVariable: sinon.stub()
+  }
+
+  const controller = proxyquire('./confirm.controller', {
+    '../../utils/response': mockResponses,
+    '../../utils/cookie': mockCookie
+  })
+
+  const service = new Service(serviceFixtures.validServiceResponse())
+
+  beforeEach(() => {
+    mockCookie.getSessionVariable.reset()
+    mockCookie.setSessionVariable.reset()
+    responseSpy.resetHistory()
+  })
+
+  describe('getPage', () => {
+    describe('when product.reference_enabled=true and product.price=null', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'invoice number',
+        price: null
+      }))
+
+      it('when the reference & amount is in the session, then it should display the confirm page ' +
+        'and update the page data with the reference value and amount', () => {
+        req = {
+          correlationId: '123',
+          product,
+          service
+        }
+        res = {
+          locals: {
+            __p: sinon.stub()
+          }
+        }
+
+        mockCookie.getSessionVariable.withArgs(req, 'referenceNumber').returns('test invoice number')
+        mockCookie.getSessionVariable.withArgs(req, 'amount').returns('10.50')
+
+        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+        controller.getPage(req, res)
+
+        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+
+        const pageData = mockResponses.response.args[0][3]
+        expect(pageData.summaryElements.length).to.equal(2)
+
+        expect(pageData.summaryElements[0].summaryLabel).to.equal('invoice number')
+        expect(pageData.summaryElements[0].summaryValue).to.equal('test invoice number')
+
+        expect(pageData.summaryElements[1].summaryLabel).to.equal('Total to pay')
+        expect(pageData.summaryElements[1].summaryValue).to.equal('£10.50')
+      })
+
+      it('when the amount is in the session, then it should display the confirm page ' +
+        'and update the page data with the amount only', () => {
+        req = {
+          correlationId: '123',
+          product,
+          service
+        }
+        res = {
+          locals: {
+            __p: sinon.stub()
+          }
+        }
+
+        mockCookie.getSessionVariable.withArgs(req, 'amount').returns('10.50')
+
+        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+        controller.getPage(req, res)
+
+        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+
+        const pageData = mockResponses.response.args[0][3]
+        expect(pageData.summaryElements.length).to.equal(1)
+        expect(pageData.summaryElements[0].summaryLabel).to.equal('Total to pay')
+        expect(pageData.summaryElements[0].summaryValue).to.equal('£10.50')
+      })
+
+      it('when there is no amount in the session, then it should display a 404 page', () => {
+        req = {
+          correlationId: '123',
+          product,
+          service
+        }
+        res = {
+          locals: {
+            __p: sinon.stub()
+          }
+        }
+
+        mockCookie.getSessionVariable.withArgs(req, 'amount').returns(null)
+
+        const next = sinon.spy()
+        controller.getPage(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(NotFoundError)
+          .and(sinon.match.has('message', 'Attempted to access confirm page without a price in the session or product.'))
+        sinon.assert.calledWith(next, expectedError)
+      })
+    })
+
+    describe('when product.reference_enabled=false and product.price=1000', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'invoice number',
+        price: 1000
+      }))
+
+      it('when the amount is in the session, then it should display the confirm page ' +
+        'and update the page data with the amount value', () => {
+        req = {
+          correlationId: '123',
+          product,
+          service
+        }
+        res = {
+          locals: {
+            __p: sinon.stub()
+          }
+        }
+
+        mockCookie.getSessionVariable.withArgs(req, 'amount').returns('10.50')
+
+        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+        controller.getPage(req, res)
+
+        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+
+        const pageData = mockResponses.response.args[0][3]
+        expect(pageData.summaryElements.length).to.equal(1)
+        expect(pageData.summaryElements[0].summaryLabel).to.equal('Total to pay')
+        expect(pageData.summaryElements[0].summaryValue).to.equal('£10.50')
+      })
+
+      it('when there is NO amount is in the session, then it should display the confirm page ' +
+        'and update the page data with the product.price', () => {
+        req = {
+          correlationId: '123',
+          product,
+          service
+        }
+        res = {
+          locals: {
+            __p: sinon.stub()
+          }
+        }
+
+        mockCookie.getSessionVariable.withArgs(req, 'amount').returns(null)
+
+        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+        controller.getPage(req, res)
+
+        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+
+        const pageData = mockResponses.response.args[0][3]
+        expect(pageData.summaryElements.length).to.equal(1)
+        expect(pageData.summaryElements[0].summaryLabel).to.equal('Total to pay')
+        expect(pageData.summaryElements[0].summaryValue).to.equal('£10.00')
+      })
+    })
+  })
+})

--- a/app/payment-link-v2/confirm/confirm.njk
+++ b/app/payment-link-v2/confirm/confirm.njk
@@ -1,9 +1,60 @@
 {% extends "../../views/layout-payment-links-v2.njk" %}
 
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+i{% from "govuk/components/button/macro.njk" import govukButton %}
+
 {% block pageTitle %}
   Confirm  - {{ productName }}
 {% endblock %}
 
 {% block contentBody %}
-  <p class="govuk-body">Confirm page placeholder text</p>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l" data-cy="product-name">{{ productName }}</h1>
+
+      <h2 class="govuk-heading-m" data-cy="reference-label">{{ __p('paymentLinksV2.confirm.checkYourDetails') }}</h2>
+
+      {% set summaryElementsList = [] %}
+      {% for summaryElement in summaryElements %}
+        {% set summaryElementsList = (summaryElementsList.push({
+            key: {
+              text: summaryElement.summaryLabel
+            },
+            value: {
+              text: summaryElement.summaryValue
+            },
+            actions: {
+              items: [
+                {
+                  href: summaryElement.changeUrl,
+                  text: "Change",
+                  visuallyHiddenText: summaryElement.summaryLabel
+                }
+              ]
+            }
+        }), summaryElementsList) %}
+      {% endfor %}
+
+      {{ govukSummaryList({
+        attributes: { 'data-cy': 'summary-list'},
+        rows: summaryElementsList
+      }) }}
+
+      <form method="post" data-cy="form">
+        <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
+
+        {% for summaryElement in summaryElements %}
+           <input
+            id="{{ summaryElement.hiddenFormFieldId }}" 
+            name="{{ summaryElement.hiddenFormFieldId }}" 
+            type="hidden" value="{{ summaryElement.summaryValue }}" />   
+        {% endfor %}
+
+        {{ govukButton({
+          text: 'Continue to payment',
+          attributes: { 'data-cy': 'continue-to-payment-button' }
+        }) }}
+      </form>
+    </div>
+  </div>
 {% endblock %}

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -53,9 +53,6 @@
     "potentialPANInReference": "Gwiriwch eich bod wedi nodi’r rhif yn gywir cyn gwneud y taliad. Peidiwch â nodi’ch rhif cerdyn debyd neu gredyd."
   },
   "paymentLinksV2": {
-    "amount": {
-      "enterAmountToPay": "TODO convert to Welsh - Enter amount to pay" 
-    },
     "reference": { 
       "pleaseEnterYour": "TODO convert to Welsh - Please enter your"
     },
@@ -65,6 +62,13 @@
 			"confirmAndContinue": "TODO convert to Welsh - Confirm and continue",
 			"edit": "TODO convert to Welsh - Edit"
 		},
+    "confirm": {
+			"checkYourDetails": "TODO convert to Welsh - Check your details",
+      "totalToPay": "TODO convert to Welsh - Total to pay" 
+		},
+    "amount": {
+      "enterAmountToPay": "TODO convert to Welsh - Enter amount to pay" 
+    },
     "fieldValidation": {
       "enterAnAmountInPounds": "TODO convert to Welsh - Enter an amount in pounds",
       "enterAnAmountInTheCorrectFormat": "TODO convert to Welsh - Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”",

--- a/locales/en.json
+++ b/locales/en.json
@@ -53,10 +53,7 @@
     "potentialPANInReference": "Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number."
   },
   "paymentLinksV2": {
-    "amount": {
-			"enterAmountToPay": "Enter amount to pay"
-		},
-		"reference": {
+    "reference": {
 			"pleaseEnterYour": "Please enter your"
 		},
 		"referenceConfirm": {
@@ -64,6 +61,13 @@
 			"checkYouveEnteredTheNumberCorrectly": "Check that you've entered the number correctly before making the payment. Do not enter your debit or credit card number.",
 			"confirmAndContinue": "Confirm and continue",
 			"edit": "Edit"
+		},
+    "amount": {
+			"enterAmountToPay": "Enter amount to pay"
+		},
+    "confirm": {
+			"checkYourDetails": "Check your details",
+      "totalToPay": "Total to pay" 
 		},
     "fieldValidation": {
       "enterAnAmountInPounds": "Enter an amount in pounds",

--- a/test/cypress/integration/confirm/confirm.cy.test.js
+++ b/test/cypress/integration/confirm/confirm.cy.test.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const productStubs = require('../../stubs/products-stubs')
+const serviceStubs = require('../../stubs/service-stubs')
+
+const gatewayAccountId = 666
+const productExternalId = 'a-product-id'
+
+describe('Confirm page', () => {
+  describe('when the Payment Link has no price', () => {
+    beforeEach(() => {
+      cy.task('setupStubs', [
+        productStubs.getProductByExternalIdStub({
+          external_id: productExternalId,
+          reference_enabled: true,
+          reference_label: 'invoice number'
+        }),
+        serviceStubs.getServiceSuccess({
+          gatewayAccountId: gatewayAccountId,
+          serviceName: {
+            en: 'Test service name'
+          }
+        })
+      ])
+
+      Cypress.Cookies.preserveOnce('session')
+    })
+
+    it('should redirect to the `Confirm` page', () => {
+      cy.visit('/pay/a-product-id/confirm')
+
+      cy.get('[data-cy=product-name]').should('contain', 'A Product Name')
+
+      cy.get('[data-cy=summary-list]').get('dt').eq(0).should('contain', 'Total to pay')
+      cy.get('[data-cy=summary-list]').get('dd').eq(0).should('contain', '£10.00')
+
+      cy.get('[data-cy=form]').get('#amount').eq(0).should('value', '£10.00')
+
+      cy.get('[data-cy=continue-to-payment-button]').should('exist')
+    })
+  })
+})


### PR DESCRIPTION
- Update controller with `getPage` function - to pass data required for the confirm page.
  - Saves the data to show in the `Summary list` table as an array.
- Update confirm page to show required data.
  - Display the data using the Design System `summary list` component.
    required by the macro.
- Add Unit tests.
- Create new Cypress test.

<img width="819" alt="image" src="https://user-images.githubusercontent.com/59831992/158168791-e377581e-9ffc-4ae7-98ce-20dbf1577d24.png">

