### PR TITLE
PP-9239: post merge tests in gha

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
     paths:
-      - './.github/workflows/post-merge.yml'
+      - .github/workflows/post-merge.yml
 
 permissions:
   contents: read

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    paths:
-      - .github/workflows/post-merge.yml
 
 permissions:
   contents: read
@@ -49,7 +46,7 @@ jobs:
           PACT_CONSUMER_VERSION: ${{ github.sha }}
           PACT_BROKER_USERNAME: ${{ secrets.pact_broker_username }}
           PACT_BROKER_PASSWORD: ${{ secrets.pact_broker_password }}
-          PACT_CONSUMER_TAG: starling-test
+          PACT_CONSUMER_TAG: master
         run: npm run publish-pacts
 
   adminusers-provider-contract-tests:
@@ -57,7 +54,7 @@ jobs:
     uses: alphagov/pay-adminusers/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: products-ui
-      consumer_tag: starling-test
+      consumer_tag: master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -67,7 +64,7 @@ jobs:
     uses: alphagov/pay-products/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: products-ui
-      consumer_tag: starling-test
+      consumer_tag: master
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -1,0 +1,70 @@
+name: Post Merge
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    uses: ./.github/workflows/run-tests.yml
+
+  publish-products-ui-consumer-contract-tests:
+    needs: tests
+    runs-on: ubuntu-18.04
+
+    name: Publish and tag products-ui consumer pact
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846
+      - name: Parse Node version
+        run: echo "##[set-output name=NVMRC;]$(cat .nvmrc)"
+        id: parse-node-version
+      - name: Setup
+        uses: actions/setup-node@9ced9a43a244f3ac94f13bfd896db8c8f30da67a
+        with:
+          node-version: "${{ steps.parse-node-version.outputs.NVMRC }}"
+      - name: Cache build directories
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: |
+            node_modules
+            govuk_modules
+            public
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Cache pacts directory
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
+      - name: Publish and tag products-ui consumer pact
+        env:
+          PACT_BROKER_URL: https://pay-pact-broker.cloudapps.digital
+          PACT_CONSUMER_VERSION: ${{ github.sha }}
+          PACT_BROKER_USERNAME: ${{ secrets.pact_broker_username }}
+          PACT_BROKER_PASSWORD: ${{ secrets.pact_broker_password }}
+          PACT_CONSUMER_TAG: master
+        run: npm run publish-pacts
+
+  adminusers-provider-contract-tests:
+    needs: publish-products-ui-consumer-contract-tests
+    uses: alphagov/pay-adminusers/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: products-ui
+      consumer_tag: master
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}
+
+  products-provider-contract-tests:
+    needs: publish-products-ui-consumer-contract-tests
+    uses: alphagov/pay-products/.github/workflows/_run-pact-provider-tests.yml@master
+    with:
+      consumer: products-ui
+      consumer_tag: master
+    secrets:
+      pact_broker_username: ${{ secrets.pact_broker_username }}
+      pact_broker_password: ${{ secrets.pact_broker_password }}

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    paths:
+      - './.github/workflows/post-merge.yml'
 
 permissions:
   contents: read
@@ -46,7 +49,7 @@ jobs:
           PACT_CONSUMER_VERSION: ${{ github.sha }}
           PACT_BROKER_USERNAME: ${{ secrets.pact_broker_username }}
           PACT_BROKER_PASSWORD: ${{ secrets.pact_broker_password }}
-          PACT_CONSUMER_TAG: master
+          PACT_CONSUMER_TAG: starling-test
         run: npm run publish-pacts
 
   adminusers-provider-contract-tests:
@@ -54,7 +57,7 @@ jobs:
     uses: alphagov/pay-adminusers/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: products-ui
-      consumer_tag: master
+      consumer_tag: starling-test
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
@@ -64,7 +67,7 @@ jobs:
     uses: alphagov/pay-products/.github/workflows/_run-pact-provider-tests.yml@master
     with:
       consumer: products-ui
-      consumer_tag: master
+      consumer_tag: starling-test
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,9 +1,7 @@
 name: Github Actions Tests
 
 on:
-  push:
-    branches:
-      - master
+  workflow_call:
   pull_request:
 
 permissions:
@@ -82,6 +80,11 @@ jobs:
             govuk_modules
             public
           key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}
+      - name: Cache pacts directory
+        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed
+        with:
+          path: pacts
+          key: ${{ runner.os }}-build-id-${{ github.head_ref }}-${{ github.sha }}-pacts
       - name: Run unit tests
         run: npm test -- --forbid-only --forbid-pending
 


### PR DESCRIPTION
1. Use post-merge.yml pattern for post-merge (calling run-tests as a reusable workflow, and don't run run-tests on PRs itself).
2. Cache pacts directory from unit tests
3. Publish consumer pact tests
4. Run provider pact tests for adminusers and products

Prior to removing the on pr on post-merge this run completed:

https://github.com/alphagov/pay-products-ui/actions/runs/1986201320
