### PR TITLE
PP-8942 Confirm page - Add recaptcha

### DIFF
--- a/app/payment-link-v2/confirm/confirm.njk
+++ b/app/payment-link-v2/confirm/confirm.njk
@@ -1,7 +1,8 @@
 {% extends "../../views/layout-payment-links-v2.njk" %}
 
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
-i{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../views/macros/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
   Confirm  - {{ productName }}
@@ -10,6 +11,10 @@ i{% from "govuk/components/button/macro.njk" import govukButton %}
 {% block contentBody %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+      {{ errorSummary ({
+        errors: errors
+      }) }}
+
       <h1 class="govuk-heading-l" data-cy="product-name">{{ productName }}</h1>
 
       <h2 class="govuk-heading-m" data-cy="reference-label">{{ __p('paymentLinksV2.confirm.checkYourDetails') }}</h2>
@@ -49,6 +54,10 @@ i{% from "govuk/components/button/macro.njk" import govukButton %}
             name="{{ summaryElement.hiddenFormFieldId }}" 
             type="hidden" value="{{ summaryElement.summaryValue }}" />   
         {% endfor %}
+
+        {% if product.requireCaptcha %}
+          <div class="g-recaptcha govuk-!-margin-bottom-5" data-sitekey="{{ GOOGLE_RECAPTCHA_SITE_KEY }}"></div>
+        {% endif %}
 
         {{ govukButton({
           text: 'Continue to payment',

--- a/app/routes.js
+++ b/app/routes.js
@@ -76,6 +76,7 @@ module.exports.bind = function (app) {
   app.post(paymentLinksV2.amount, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, amountCtrl.postPage)
 
   app.get(paymentLinksV2.confirm, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, confirmCtrl.getPage)
+  app.post(paymentLinksV2.confirm, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, confirmCtrl.postPage)
 
   // security.txt — https://gds-way.cloudapps.digital/standards/vulnerability-disclosure.html
   const securitytxt = 'https://vdp.cabinetoffice.gov.uk/.well-known/security.txt'

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -62,20 +62,22 @@
 			"confirmAndContinue": "TODO convert to Welsh - Confirm and continue",
 			"edit": "TODO convert to Welsh - Edit"
 		},
+
+    "amount": {
+      "enterAmountToPay": "TODO convert to Welsh - Enter amount to pay" 
+    },
     "confirm": {
 			"checkYourDetails": "TODO convert to Welsh - Check your details",
       "totalToPay": "TODO convert to Welsh - Total to pay" 
 		},
-    "amount": {
-      "enterAmountToPay": "TODO convert to Welsh - Enter amount to pay" 
-    },
     "fieldValidation": {
       "enterAnAmountInPounds": "TODO convert to Welsh - Enter an amount in pounds",
       "enterAnAmountInTheCorrectFormat": "TODO convert to Welsh - Enter an amount in pounds and pence using digits and a decimal point. For example “10.50”",
       "enterAnAmountUnderMaxAmount": "TODO convert to Welsh - Enter an amount that is £100,000 or under",
       "enterAReference": "TODO convert to Welsh - Enter a valid %s",
       "referenceMustBeLessThanOrEqual50Chars": "TODO convert to Welsh - %s must be less than or equal to 50 characters",
-      "referenceCantUseInvalidChars": "TODO convert to Welsh - %s can’t contain any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]"
+      "referenceCantUseInvalidChars": "TODO convert to Welsh - %s can’t contain any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
+      "youMustSelectIAmNotARobot": "TODO convert to Welsh - You must select 'I am not a robot' before proceeding to payment."
     }
   } 
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -75,7 +75,8 @@
       "enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or under",
       "enterAReference": "Enter a valid %s",
       "referenceMustBeLessThanOrEqual50Chars": "%s must be less than or equal to 50 characters",
-      "referenceCantUseInvalidChars": "%s can’t contain any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]"
+      "referenceCantUseInvalidChars": "%s can’t contain any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
+      "youMustSelectIAmNotARobot": "You must select 'I am not a robot' before proceeding to payment."
     }
   }
 }


### PR DESCRIPTION
- Add POST route for the `confirm` page.
- Add code to handle Recaptcha functionality.
  - Update `confirm` nunjuks file.
  - Add tests.
    - Will add the `success` test once the payment code is in place.
- Refactor code - to move the summaryElements code to a new method -
  getSummaryElements()
  - So it can be used for both the GET and POST methods.