### PR TITLE
PP-8942 Confirm page - add payment code

### DIFF
--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -29,8 +29,6 @@ module.exports = function (err, req, res, next) {
     }
   }
 
-  // log the exception
   logger.error(`[requestId=${req.correlationId}] Internal server error`, errorPayload)
-  // re-throw it
-  next(err)
+  return response(req, res, '500')
 }

--- a/app/views/404.njk
+++ b/app/views/404.njk
@@ -1,10 +1,10 @@
 {% extends "./layout-payment-links-v2.njk" %}
 
 {% block pageTitle %}
-  Page not found - GOV.UK Pay
+  {{ __p('404Page.title') }} - GOV.UK Pay
 {% endblock %}
 
 {% block contentBody %}
-    <h1 class="govuk-heading-l">Page not found</h1>
-    <p class="govuk-body">Sorry, we could not find the page you were looking for.</p>
+    <h1 class="govuk-heading-l">{{ __p('404Page.title') }}</h1>
+    <p class="govuk-body">{{ __p('404Page.bodyText') }}</p>
 {% endblock %}

--- a/app/views/500.njk
+++ b/app/views/500.njk
@@ -1,0 +1,10 @@
+{% extends "./layout-payment-links-v2.njk" %}
+
+{% block pageTitle %}
+  {{ __p('error.title') }} - GOV.UK Pay
+{% endblock %}
+
+{% block contentBody %}
+    <h1 class="govuk-heading-l">{{ __p('error.title') }}</h1>
+    <p class="govuk-body">{{ __p('error.default')}}</p>
+{% endblock %}

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -19,6 +19,10 @@
     "default": "Mae’n ddrwg gennym, ond ni allwn brosesu eich cais. Rhowch gynnig arall arni wedyn.",
     "internal": "Mae problem gyda’r cyfleuster taliadau. Rhowch gynnig arall arni wedyn"
   },
+  "404Page": {
+    "title": "TODO convert to Welsh - Page not found",
+    "bodyText": "TODO convert to Welsh - Sorry, we could not find the page you were looking for."
+  },
   "confirmation": {
     "title": "Roedd eich taliad yn llwyddiannus",
     "titleMoto": "Roedd y taliad yn llwyddiannus",

--- a/locales/en.json
+++ b/locales/en.json
@@ -19,6 +19,10 @@
     "default": "There’s a problem with the payments platform. Please try again later",
     "internal": "Sorry, we’re unable to process your request. Try again later."
   },
+  "404Page": {
+    "title": "Page not found",
+    "bodyText": "Sorry, we could not find the page you were looking for."
+  },
   "confirmation": {
     "title": "Your payment was successful",
     "titleMoto": "The payment was successful",


### PR DESCRIPTION
- Update `confirm.controller.js` - to add code to create
  payment.
  - Uses the `productClient` to create a charge.
  - Redirect the user to the charge > next.url.
  - If the call to `products client > create payment` fails - redirect to a
    a new 500 page.
  - Add unit tests.