### PR TITLE
PP-8982 Add payment link session utilities

### DIFF
--- a/app/controllers/pre-payment.controller.js
+++ b/app/controllers/pre-payment.controller.js
@@ -11,7 +11,7 @@ const { paymentLinksV2 } = require('../paths')
 // Constants
 const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
 
-function getContinueUrlForNewPaymentLinkJourney(product) {
+function getContinueUrlForNewPaymentLinkJourney (product) {
   if (product.reference_enabled) {
     return replaceParamsInPath(paymentLinksV2.reference, product.externalId)
   }
@@ -20,7 +20,6 @@ function getContinueUrlForNewPaymentLinkJourney(product) {
   }
   return replaceParamsInPath(paymentLinksV2.confirm, product.externalId)
 }
-
 
 module.exports = (req, res) => {
   const product = req.product
@@ -38,8 +37,7 @@ module.exports = (req, res) => {
         return response(req, res, 'start/start', {
           continueUrl
         })
-      }
-      else if (product.reference_enabled) {
+      } else if (product.reference_enabled) {
         return productReferenceCtrl.index(req, res)
       } else {
         return adhocPaymentCtrl.index(req, res)

--- a/app/controllers/pre-payment.controller.test.js
+++ b/app/controllers/pre-payment.controller.test.js
@@ -24,7 +24,6 @@ const controller = proxyquire('./pre-payment.controller', {
 const productExternalId = 'product-external-id'
 
 describe('Pre payment controller', () => {
-
   beforeEach(() => {
     mockResponse.response.resetHistory()
   })

--- a/app/payment-link-v2/utils/payment-link-session.js
+++ b/app/payment-link-v2/utils/payment-link-session.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const lodash = require('lodash')
+const { getSessionCookieName } = require('../../utils/cookie')
+
+function getReference (req, productExternalId) {
+  const sessionName = getSessionCookieName()
+  return lodash.get(req, `${sessionName}.${productExternalId}.reference`)
+}
+
+function setReference (req, productExternalId, reference) {
+  const sessionName = getSessionCookieName()
+  lodash.set(req, `${sessionName}.${productExternalId}.reference`, reference)
+}
+
+function getAmount (req, productExternalId) {
+  const sessionName = getSessionCookieName()
+  return lodash.get(req, `${sessionName}.${productExternalId}.amount`)
+}
+
+function setAmount (req, productExternalId, amount) {
+  const sessionName = getSessionCookieName()
+  lodash.set(req, `${sessionName}.${productExternalId}.amount`, amount)
+}
+
+function deletePaymentLinkSession (req, productExternalId) {
+  const sessionName = getSessionCookieName()
+  lodash.unset(req, `${sessionName}.${productExternalId}`)
+}
+
+module.exports = {
+  getReference,
+  setReference,
+  getAmount,
+  setAmount,
+  deletePaymentLinkSession
+}

--- a/app/payment-link-v2/utils/payment-link-session.test.js
+++ b/app/payment-link-v2/utils/payment-link-session.test.js
@@ -1,0 +1,123 @@
+const { expect } = require('chai')
+
+const paymentLinkSession = require('./payment-link-session')
+
+const productExternalId = 'a-product-external-id'
+const reference = 'REF123'
+const amount = 1234
+
+describe('Payment link session utilities', () => {
+  describe('Get reference', () => {
+    it('should return undefined when there is no session', () => {
+      const req = {}
+      const sessionRef = paymentLinkSession.getReference(req, productExternalId)
+      expect(sessionRef).to.equal(undefined)
+    })
+
+    it('should return reference from session', () => {
+      const req = {
+        session: {
+          'a-product-external-id': {
+            reference
+          }
+        }
+      }
+      const sessionRef = paymentLinkSession.getReference(req, productExternalId)
+      expect(sessionRef).to.equal(reference)
+    })
+  })
+
+  describe('Set reference', () => {
+    it('should set the reference when there is no payment link session', () => {
+      const req = {}
+      paymentLinkSession.setReference(req, productExternalId, reference)
+
+      const sessionRef = paymentLinkSession.getReference(req, productExternalId)
+      expect(sessionRef).to.equal(reference)
+    })
+
+    it('should override existing reference', () => {
+      const req = {
+        session: {
+          'a-product-external-id': {
+            reference: 'OLDREF'
+          }
+        }
+      }
+      paymentLinkSession.setReference(req, productExternalId, reference)
+
+      const sessionRef = paymentLinkSession.getReference(req, productExternalId)
+      expect(sessionRef).to.equal(reference)
+    })
+  })
+
+  describe('Get amount', () => {
+    it('should return undefined when there is no session', () => {
+      const req = {}
+      const sessionAmount = paymentLinkSession.getAmount(req, productExternalId)
+      expect(sessionAmount).to.equal(undefined)
+    })
+
+    it('should return amount from session', () => {
+      const req = {
+        session: {
+          'a-product-external-id': {
+            amount
+          }
+        }
+      }
+      const sessionRef = paymentLinkSession.getAmount(req, productExternalId)
+      expect(sessionRef).to.equal(amount)
+    })
+  })
+
+  describe('Set amount', () => {
+    it('should set the amount when there is no payment link session', () => {
+      const req = {}
+      paymentLinkSession.setAmount(req, productExternalId, amount)
+
+      const sessionAmount = paymentLinkSession.getAmount(req, productExternalId)
+      expect(sessionAmount).to.equal(amount)
+    })
+
+    it('should override existing amount', () => {
+      const req = {
+        session: {
+          'a-product-external-id': {
+            amount: 2
+          }
+        }
+      }
+      paymentLinkSession.setAmount(req, productExternalId, amount)
+
+      const sessionAmount = paymentLinkSession.getAmount(req, productExternalId)
+      expect(sessionAmount).to.equal(amount)
+    })
+  })
+
+  describe('Delete session', () => {
+    it('should delete session for product external id', () => {
+      const req = {
+        session: {
+          'a-product-external-id-1': {
+            reference: 'REF1',
+            amount: 1
+          },
+          'a-product-external-id-2': {
+            reference: 'REF2',
+            amount: 2
+          }
+        }
+      }
+      paymentLinkSession.deletePaymentLinkSession(req, 'a-product-external-id-1')
+      expect(req).to.deep.equal({
+        session: {
+          'a-product-external-id-2': {
+            reference: 'REF2',
+            amount: 2
+          }
+        }
+      })
+    })
+  })
+})

--- a/app/utils/cookie.js
+++ b/app/utils/cookie.js
@@ -93,7 +93,8 @@ function setValueOnCookie (req, key, value, cookieName) {
 }
 
 module.exports = {
-  sessionCookie: sessionCookie,
-  setSessionVariable: setSessionVariable,
-  getSessionVariable: getSessionVariable
+  sessionCookie,
+  setSessionVariable,
+  getSessionVariable,
+  getSessionCookieName
 }

--- a/bin/publish-pacts.js
+++ b/bin/publish-pacts.js
@@ -4,7 +4,7 @@ const path = require('path')
 const pact = require('@pact-foundation/pact-node')
 const pactDirPath = `${__dirname}/../pacts/`
 const opts = {
-  pactFilesOrDirs: [ pactDirPath ],
+  pactFilesOrDirs: [pactDirPath],
   pactBroker: process.env.PACT_BROKER_URL,
   consumerVersion: process.env.PACT_CONSUMER_VERSION,
   pactBrokerUsername: process.env.PACT_BROKER_USERNAME,
@@ -17,7 +17,7 @@ readdir(pactDirPath)
     files
       .filter((file) => file.includes('to-be'))
       .map((file) => unlink(path.join(pactDirPath, file)))
-    )
+  )
   )
   .then(() => pact.publishPacts(opts))
   .then(() => console.log('>> Pact files have been published'))

--- a/test/cypress/integration/payment-link-v2/start.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/start.cy.test.js
@@ -84,7 +84,7 @@ describe('The payment link start page', () => {
           description: null
         }),
         serviceStubs.getServiceSuccess({
-          gatewayAccountId: gatewayAccountId,
+          gatewayAccountId: gatewayAccountId
         })
       ])
 


### PR DESCRIPTION
We want to index the session for payment links by the product external id. This is because there is an existing issue that can cause the session to be interfered with if 2 payment links are opened in different browser tabs and completed alongside each other.

If a payment link is abandoned, the cookie will also remain in the users browser for next time they try to complete a payment link if it has not expired.

Indexing the session by product external ID will ensure at least that a session cookie remaining from filling in one payment link is not picked up by a user attempting to complete a completely different payment link which will more than likely require a different reference and amount.

These utility methods are intended to be used whenever we read/write from the payment link session.