### PR TITLE
PP-8982 Index session by product external id

### DIFF
--- a/app/payment-link-v2/amount/amount.controller.js
+++ b/app/payment-link-v2/amount/amount.controller.js
@@ -3,13 +3,12 @@
 const lodash = require('lodash')
 
 const { response } = require('../../utils/response')
-const { getSessionVariable } = require('../../utils/cookie')
 const { NotFoundError } = require('../../errors')
 const getBackLinkUrl = require('./get-back-link-url')
 const paths = require('../../paths')
 const { validateAmount } = require('../../utils/validation/form-validations')
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
-const { setSessionVariable } = require('../../utils/cookie')
+const paymentLinkSession = require('../utils/payment-link-session')
 
 const PAYMENT_AMOUNT = 'payment-amount'
 
@@ -35,7 +34,7 @@ function getPage (req, res, next) {
     return next(new NotFoundError('Attempted to access amount page with a product that already has a price.'))
   }
 
-  const sessionAmount = getSessionVariable(req, 'amount')
+  const sessionAmount = paymentLinkSession.getAmount(req, product.externalId)
 
   data.backLinkHref = getBackLinkUrl(sessionAmount, product)
 
@@ -52,7 +51,7 @@ function postPage (req, res, next) {
 
   const product = req.product
 
-  const sessionAmount = getSessionVariable(req, 'amount')
+  const sessionAmount = paymentLinkSession.getAmount(req, product.externalId)
   const backLinkHref = getBackLinkUrl(sessionAmount, product)
 
   const data = {
@@ -70,7 +69,7 @@ function postPage (req, res, next) {
 
   const paymentAmountInPence = parseFloat(paymentAmount) * 100
 
-  setSessionVariable(req, 'amount', paymentAmountInPence)
+  paymentLinkSession.setAmount(req, product.externalId, paymentAmountInPence)
 
   return res.redirect(replaceParamsInPath(paths.paymentLinksV2.confirm, product.externalId))
 }

--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -4,11 +4,11 @@ const lodash = require('lodash')
 const { response } = require('../../utils/response')
 const { paymentLinksV2 } = require('../../paths')
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
-const { getSessionVariable } = require('../../utils/cookie')
 const { NotFoundError } = require('../../errors')
 const captcha = require('../../utils/captcha')
 const logger = require('../../utils/logger')(__filename)
 const productsClient = require('../../services/clients/products.client')
+const paymentLinkSession = require('../utils/payment-link-session')
 
 const HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE = 'reference-value'
 const HIDDEN_FORM_FIELD_ID_AMOUNT = 'amount'
@@ -94,8 +94,8 @@ function getRightAmountToDisplayAsGbp (sessionAmount, productAmount) {
 function getPage (req, res, next) {
   const product = req.product
 
-  const sessionReferenceNumber = getSessionVariable(req, 'referenceNumber')
-  const sessionAmount = getSessionVariable(req, 'amount')
+  const sessionReferenceNumber = paymentLinkSession.getReference(req, product.externalId)
+  const sessionAmount = paymentLinkSession.getAmount(req, product.externalId)
 
   if (!sessionAmount && !product.price) {
     return next(new NotFoundError('Attempted to access confirm page without a price in the session or product.'))

--- a/app/payment-link-v2/confirm/confirm.controller.test.js
+++ b/app/payment-link-v2/confirm/confirm.controller.test.js
@@ -18,9 +18,9 @@ const mockResponses = {
 let req, res
 
 describe('Confirm Page Controller', () => {
-  const mockCookie = {
-    getSessionVariable: sinon.stub(),
-    setSessionVariable: sinon.stub()
+  const mockPaymentLinkSession = {
+    getAmount: sinon.stub(),
+    getReference: sinon.stub()
   }
 
   const mockCaptcha = {
@@ -35,7 +35,7 @@ describe('Confirm Page Controller', () => {
 
   const controller = proxyquire('./confirm.controller', {
     '../../utils/response': mockResponses,
-    '../../utils/cookie': mockCookie,
+    '../utils/payment-link-session': mockPaymentLinkSession,
     '../../utils/captcha': mockCaptcha,
     '../../services/clients/products.client': mockProductsClient
   })
@@ -43,8 +43,8 @@ describe('Confirm Page Controller', () => {
   const service = new Service(serviceFixtures.validServiceResponse())
 
   beforeEach(() => {
-    mockCookie.getSessionVariable.reset()
-    mockCookie.setSessionVariable.reset()
+    mockPaymentLinkSession.getAmount.reset()
+    mockPaymentLinkSession.getReference.reset()
     responseSpy.resetHistory()
     mockCaptcha.verifyCAPTCHAToken.reset()
     mockProductsClient.payment.create.reset()
@@ -72,8 +72,8 @@ describe('Confirm Page Controller', () => {
           }
         }
 
-        mockCookie.getSessionVariable.withArgs(req, 'referenceNumber').returns('test invoice number')
-        mockCookie.getSessionVariable.withArgs(req, 'amount').returns('1050')
+        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
+        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns('1050')
 
         res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
 
@@ -110,7 +110,7 @@ describe('Confirm Page Controller', () => {
           }
         }
 
-        mockCookie.getSessionVariable.withArgs(req, 'amount').returns('1050')
+        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns('1050')
 
         res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
 
@@ -139,7 +139,7 @@ describe('Confirm Page Controller', () => {
           }
         }
 
-        mockCookie.getSessionVariable.withArgs(req, 'amount').returns(null)
+        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(null)
 
         const next = sinon.spy()
         controller.getPage(req, res, next)
@@ -171,7 +171,7 @@ describe('Confirm Page Controller', () => {
           }
         }
 
-        mockCookie.getSessionVariable.withArgs(req, 'amount').returns('1050')
+        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns('1050')
 
         res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
 
@@ -201,7 +201,7 @@ describe('Confirm Page Controller', () => {
           }
         }
 
-        mockCookie.getSessionVariable.withArgs(req, 'amount').returns(null)
+        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(null)
 
         res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
 

--- a/app/payment-link-v2/reference-confirm/reference-confirm.controller.js
+++ b/app/payment-link-v2/reference-confirm/reference-confirm.controller.js
@@ -1,10 +1,10 @@
 'use strict'
 
 const { response } = require('../../utils/response')
-const { getSessionVariable } = require('../../utils/cookie')
 const { NotFoundError } = require('../../errors')
 const { paymentLinksV2 } = require('../../paths')
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
+const paymentLinkSession = require('../utils/payment-link-session')
 
 function getPage (req, res, next) {
   const product = req.product
@@ -26,7 +26,7 @@ function getPage (req, res, next) {
   const confirmAndContinueUrlPath = product.price ? paymentLinksV2.confirm : paymentLinksV2.amount
   data.confirmAndContinuePageUrl = replaceParamsInPath(confirmAndContinueUrlPath, product.externalId)
 
-  const sessionReferenceNumber = getSessionVariable(req, 'referenceNumber')
+  const sessionReferenceNumber = paymentLinkSession.getReference(req, product.externalId)
 
   if (sessionReferenceNumber) {
     data.reference = sessionReferenceNumber

--- a/app/payment-link-v2/reference-confirm/reference-confirm.controller.test.js
+++ b/app/payment-link-v2/reference-confirm/reference-confirm.controller.test.js
@@ -18,19 +18,19 @@ const mockResponses = {
 let req, res
 
 describe('Reference Confirm Page Controller', () => {
-  const mockCookie = {
-    getSessionVariable: sinon.stub()
+  const mockPaymentLinkSession = {
+    getReference: sinon.stub()
   }
 
   const controller = proxyquire('./reference-confirm.controller', {
     '../../utils/response': mockResponses,
-    '../../utils/cookie': mockCookie
+    '../utils/payment-link-session': mockPaymentLinkSession
   })
 
   const service = new Service(serviceFixtures.validServiceResponse())
 
   beforeEach(() => {
-    mockCookie.getSessionVariable.reset()
+    mockPaymentLinkSession.getReference.reset()
     responseSpy.resetHistory()
   })
 
@@ -46,8 +46,6 @@ describe('Reference Confirm Page Controller', () => {
       it('when the reference is in the session, then it should display the REFERENCE CONFIRM page ' +
         'and set the `back` link to the REFERENCE page ' +
         'and set the  `confirm and continue` link to the AMOUNT page', () => {
-        mockCookie.getSessionVariable.returns('refrence test value')
-
         req = {
           correlationId: '123',
           product,
@@ -60,13 +58,13 @@ describe('Reference Confirm Page Controller', () => {
             __p: sinon.stub()
           }
         }
-
+        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('reference test value')
         controller.getPage(req, res)
 
         sinon.assert.calledWith(responseSpy, req, res, 'reference-confirm/reference-confirm')
 
         const pageData = mockResponses.response.args[0][3]
-        expect(pageData.reference).to.equal('refrence test value')
+        expect(pageData.reference).to.equal('reference test value')
         expect(pageData.referencePageUrl).to.equal('/pay/an-external-id/reference')
         expect(pageData.confirmAndContinuePageUrl).to.equal('/pay/an-external-id/amount')
       })
@@ -83,8 +81,6 @@ describe('Reference Confirm Page Controller', () => {
       it('when the reference is in the session, then it should display the REFERENCE CONFIRM page ' +
         'and set the `back` link to the REFERENCE page' +
         'and set the  `confirm and continue` link to the CONFIRM page', () => {
-        mockCookie.getSessionVariable.returns('refrence test value')
-
         req = {
           correlationId: '123',
           product,
@@ -97,13 +93,13 @@ describe('Reference Confirm Page Controller', () => {
             __p: sinon.stub()
           }
         }
-
+        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('reference test value')
         controller.getPage(req, res)
 
         sinon.assert.calledWith(responseSpy, req, res, 'reference-confirm/reference-confirm')
 
         const pageData = mockResponses.response.args[0][3]
-        expect(pageData.reference).to.equal('refrence test value')
+        expect(pageData.reference).to.equal('reference test value')
         expect(pageData.referencePageUrl).to.equal('/pay/an-external-id/reference')
         expect(pageData.confirmAndContinuePageUrl).to.equal('/pay/an-external-id/confirm')
       })

--- a/app/payment-link-v2/utils/payment-link-session.js
+++ b/app/payment-link-v2/utils/payment-link-session.js
@@ -3,29 +3,31 @@
 const lodash = require('lodash')
 const { getSessionCookieName } = require('../../utils/cookie')
 
+const REFERENCE_KEY = 'reference'
+const AMOUNT_KEY = 'amount'
+
+function cookieIndex (key, productExternalId) {
+  return `${getSessionCookieName()}.${productExternalId}.${key}`
+}
+
 function getReference (req, productExternalId) {
-  const sessionName = getSessionCookieName()
-  return lodash.get(req, `${sessionName}.${productExternalId}.reference`)
+  return lodash.get(req, cookieIndex(REFERENCE_KEY, productExternalId))
 }
 
 function setReference (req, productExternalId, reference) {
-  const sessionName = getSessionCookieName()
-  lodash.set(req, `${sessionName}.${productExternalId}.reference`, reference)
+  lodash.set(req, cookieIndex(REFERENCE_KEY, productExternalId), reference)
 }
 
 function getAmount (req, productExternalId) {
-  const sessionName = getSessionCookieName()
-  return lodash.get(req, `${sessionName}.${productExternalId}.amount`)
+  return lodash.get(req, cookieIndex(AMOUNT_KEY, productExternalId))
 }
 
 function setAmount (req, productExternalId, amount) {
-  const sessionName = getSessionCookieName()
-  lodash.set(req, `${sessionName}.${productExternalId}.amount`, amount)
+  lodash.set(req, cookieIndex(AMOUNT_KEY, productExternalId), amount)
 }
 
 function deletePaymentLinkSession (req, productExternalId) {
-  const sessionName = getSessionCookieName()
-  lodash.unset(req, `${sessionName}.${productExternalId}`)
+  lodash.unset(req, `${getSessionCookieName()}.${productExternalId}`)
 }
 
 module.exports = {


### PR DESCRIPTION
Wherever we get or set the reference or amount on the session, replace
this with method calls to the new utility methods which index the
session by the product external id.