### PR TITLE
PP-8942 - Confirm page - fix bugs.

### DIFF
--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -51,7 +51,7 @@ async function validateRecaptcha (
 
 function getSummaryElements (
   referenceNumber,
-  amount,
+  sessionAmount,
   productReferenceLabel,
   productExternalId,
   productPrice,
@@ -72,21 +72,22 @@ function getSummaryElements (
   const changeAmountUrl = replaceParamsInPath(paymentLinksV2.amount, productExternalId)
   const totalToPayText = translationMethod('paymentLinksV2.confirm.totalToPay')
 
-  const amountAsGbp = getRightAmountToDisplayAsGbp(amount, productPrice)
+  const amountToUse = productPrice || sessionAmount
+  const amountAsGbp = getRightAmountToDisplayAsGbp(amountToUse)
 
   summaryElements.push(generateSummaryElement(
     totalToPayText,
     amountAsGbp,
-    changeAmountUrl,
+    productPrice ? null : changeAmountUrl,
     HIDDEN_FORM_FIELD_ID_AMOUNT,
-    amount || productPrice
+    amountToUse
   ))
 
   return summaryElements
 }
 
-function getRightAmountToDisplayAsGbp (sessionAmount, productAmount) {
-  const amountToDisplay = (parseFloat(sessionAmount || productAmount) / 100).toFixed(2)
+function getRightAmountToDisplayAsGbp (amount) {
+  const amountToDisplay = (parseFloat(amount) / 100).toFixed(2)
 
   return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(amountToDisplay)
 }
@@ -129,6 +130,9 @@ async function postPage (req, res, next) {
     productName: product.name
   }
 
+  const amountToUse = parseInt(product.price || req.body[HIDDEN_FORM_FIELD_ID_AMOUNT])
+  const referenceValueToUse = product.reference_enabled ? req.body[HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE] : null
+
   if (product.requireCaptcha) {
     const errors = await validateRecaptcha(
       req.body[GOOGLE_RECAPTCHA_FORM_NAME],
@@ -139,7 +143,7 @@ async function postPage (req, res, next) {
       data.errors = errors
 
       const summaryElements = getSummaryElements(
-        req.body[HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE],
+        referenceValueToUse,
         req.body[HIDDEN_FORM_FIELD_ID_AMOUNT],
         product.reference_label,
         product.externalId,
@@ -155,10 +159,11 @@ async function postPage (req, res, next) {
 
   try {
     logger.info(`[${req.correlationId}] creating charge for product ${product.externalId}`)
+
     const payment = await productsClient.payment.create(
       product.externalId,
-      req.body[HIDDEN_FORM_FIELD_ID_AMOUNT],
-      req.body[HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE]
+      amountToUse,
+      referenceValueToUse
     )
 
     res.redirect(303, payment.links.next.href)

--- a/app/payment-link-v2/confirm/confirm.controller.test.js
+++ b/app/payment-link-v2/confirm/confirm.controller.test.js
@@ -158,38 +158,7 @@ describe('Confirm Page Controller', () => {
         price: 1000
       }))
 
-      it('when the amount is in the session, then it should display the confirm page ' +
-        'and update the page data with the amount value', () => {
-        req = {
-          correlationId: '123',
-          product,
-          service
-        }
-        res = {
-          locals: {
-            __p: sinon.stub()
-          }
-        }
-
-        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns('1050')
-
-        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
-
-        controller.getPage(req, res)
-
-        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
-
-        const pageData = mockResponses.response.args[0][3]
-        expect(pageData.summaryElements.length).to.equal(1)
-        expect(pageData.summaryElements[0].summaryLabel).to.equal('Total to pay')
-        expect(pageData.summaryElements[0].summaryValue).to.equal('£10.50')
-        expect(pageData.summaryElements[0].changeUrl).to.equal('/pay/an-external-id/amount')
-        expect(pageData.summaryElements[0].hiddenFormFieldId).to.equal('amount')
-        expect(pageData.summaryElements[0].hiddenFormFieldValue).to.equal('1050')
-      })
-
-      it('when there is NO amount is in the session, then it should display the confirm page ' +
-        'and update the page data with the product.price', () => {
+      it('then it should display the confirm page with the `product.price` value', () => {
         req = {
           correlationId: '123',
           product,
@@ -213,7 +182,37 @@ describe('Confirm Page Controller', () => {
         expect(pageData.summaryElements.length).to.equal(1)
         expect(pageData.summaryElements[0].summaryLabel).to.equal('Total to pay')
         expect(pageData.summaryElements[0].summaryValue).to.equal('£10.00')
-        expect(pageData.summaryElements[0].changeUrl).to.equal('/pay/an-external-id/amount')
+        expect(pageData.summaryElements[0].changeUrl).to.equal(null)
+        expect(pageData.summaryElements[0].hiddenFormFieldId).to.equal('amount')
+        expect(pageData.summaryElements[0].hiddenFormFieldValue).to.equal(1000)
+      })
+
+      it('when the amount is in the session, then it should ignore the amount in the session and ' +
+        'display the confirm page with the `product.price` value', () => {
+        req = {
+          correlationId: '123',
+          product,
+          service
+        }
+        res = {
+          locals: {
+            __p: sinon.stub()
+          }
+        }
+
+        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns('1050')
+
+        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+        controller.getPage(req, res)
+
+        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+
+        const pageData = mockResponses.response.args[0][3]
+        expect(pageData.summaryElements.length).to.equal(1)
+        expect(pageData.summaryElements[0].summaryLabel).to.equal('Total to pay')
+        expect(pageData.summaryElements[0].summaryValue).to.equal('£10.00')
+        expect(pageData.summaryElements[0].changeUrl).to.equal(null)
         expect(pageData.summaryElements[0].hiddenFormFieldId).to.equal('amount')
         expect(pageData.summaryElements[0].hiddenFormFieldValue).to.equal(1000)
       })
@@ -221,22 +220,23 @@ describe('Confirm Page Controller', () => {
   })
 
   describe('postPage', () => {
-    describe('when product.requireCaptcha=false and product.price=1000', () => {
+    describe('when product.requireCaptcha=false, reference_enabled=false, product.price=null, ', () => {
       const product = new Product(productFixtures.validProductResponse({
         type: 'ADHOC',
-        reference_label: 'Invoice number',
-        reference_enabled: true,
-        price: 1000
+        reference_enabled: false,
+        price: null
       }))
 
-      it('when `click and continue` is clicked, should redirect to the ' +
-        'next_url', async () => {
+      it('when `click and continue` is clicked, should create a payment with no reference and ' +
+        'ignore the hidden reference form field and ' +
+        'use the amount from the hidden amount form field and ' +
+        'redirect to the next_url ', async () => {
         req = {
           correlationId: '123',
           product,
           body: {
             'reference-value': 'a-invoice-number',
-            amount: '1000'
+            amount: '2000'
           }
         }
 
@@ -257,14 +257,13 @@ describe('Confirm Page Controller', () => {
         sinon.assert.calledWith(
           mockProductsClient.payment.create,
           'an-external-id',
-          '1000',
-          'a-invoice-number'
+          2000,
+          null
         )
         sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
       })
 
-      it('when an error occurs when creating a payment, should call next() with ' +
-      'an error', async () => {
+      it('when creating a payment and an error occurs, should call next() with an error', async () => {
         req = {
           correlationId: '123',
           product,
@@ -287,8 +286,7 @@ describe('Confirm Page Controller', () => {
         sinon.assert.calledWith(
           mockProductsClient.payment.create,
           'an-external-id',
-          '1000',
-          'a-invoice-number'
+          1000
         )
 
         const expectedError = sinon.match.instanceOf(Error)
@@ -297,7 +295,140 @@ describe('Confirm Page Controller', () => {
       })
     })
 
-    describe('when product.requireCaptcha=true and product.price=1000', () => {
+    describe('when product.requireCaptcha=false, reference_enabled=true, product.price=null, ', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        price: null
+      }))
+
+      it('when `click and continue` is clicked, should create a payment with a reference ' +
+        'using the `hidden reference form field` and ' +
+        'use the amount from the `hidden amount form field` and ' +
+        'redirect to the next_url ', async () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'reference-value': 'a-invoice-number',
+            amount: '2000'
+          }
+        }
+
+        res = {
+          redirect: sinon.stub()
+        }
+
+        mockProductsClient.payment.create.resolves({
+          links: {
+            next: {
+              href: 'https://test.com'
+            }
+          }
+        })
+
+        await controller.postPage(req, res)
+
+        sinon.assert.calledWith(
+          mockProductsClient.payment.create,
+          'an-external-id',
+          2000,
+          'a-invoice-number'
+        )
+        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
+      })
+    })
+
+    describe('when product.requireCaptcha=false, reference_enabled=false, product.price=1000, ', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: false,
+        price: 1000
+      }))
+
+      it('when `click and continue` is clicked, should create a payment with NO reference and ' +
+        'ignore the `hidden reference form field` and ' +
+        'use the product.price and ' +
+        'ignore `hidden amount form field` and ' +
+        'redirect to the next_url ', async () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'reference-value': 'a-invoice-number',
+            amount: '2000'
+          }
+        }
+
+        res = {
+          redirect: sinon.stub()
+        }
+
+        mockProductsClient.payment.create.resolves({
+          links: {
+            next: {
+              href: 'https://test.com'
+            }
+          }
+        })
+
+        await controller.postPage(req, res)
+
+        sinon.assert.calledWith(
+          mockProductsClient.payment.create,
+          'an-external-id',
+          1000
+        )
+        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
+      })
+    })
+
+    describe('when product.requireCaptcha=false, reference_enabled=true, product.price=1000, ', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        price: 1000
+      }))
+
+      it('when `click and continue` is clicked, should create a payment with a reference and ' +
+        'use the `hidden reference form field` and ' +
+        'use the product.price and ' +
+        'ignore `hidden amount form field` and ' +
+        'redirect to the next_url', async () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'reference-value': 'a-invoice-number',
+            amount: '2000'
+          }
+        }
+
+        res = {
+          redirect: sinon.stub()
+        }
+
+        mockProductsClient.payment.create.resolves({
+          links: {
+            next: {
+              href: 'https://test.com'
+            }
+          }
+        })
+
+        await controller.postPage(req, res)
+
+        sinon.assert.calledWith(
+          mockProductsClient.payment.create,
+          'an-external-id',
+          1000,
+          'a-invoice-number'
+        )
+        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
+      })
+    })
+
+    describe('when product.requireCaptcha=true, reference_enabled=true, product.price=1000', () => {
       const product = new Product(productFixtures.validProductResponse({
         type: 'ADHOC',
         reference_label: 'Invoice number',
@@ -342,7 +473,7 @@ describe('Confirm Page Controller', () => {
         sinon.assert.calledWith(
           mockProductsClient.payment.create,
           'an-external-id',
-          '1000',
+          1000,
           'a-invoice-number'
         )
         sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
@@ -356,7 +487,7 @@ describe('Confirm Page Controller', () => {
           product,
           body: {
             'reference-value': 'a-invoice-number',
-            amount: '1000',
+            amount: '2000',
             'g-recaptcha-response': 'recaptcha-test-token'
           }
         }
@@ -386,9 +517,9 @@ describe('Confirm Page Controller', () => {
 
         expect(pageData.summaryElements[1].summaryLabel).to.equal('Total to pay')
         expect(pageData.summaryElements[1].summaryValue).to.equal('£10.00')
-        expect(pageData.summaryElements[1].changeUrl).to.equal('/pay/an-external-id/amount')
+        expect(pageData.summaryElements[1].changeUrl).to.equal(null)
         expect(pageData.summaryElements[1].hiddenFormFieldId).to.equal('amount')
-        expect(pageData.summaryElements[1].hiddenFormFieldValue).to.equal('1000')
+        expect(pageData.summaryElements[1].hiddenFormFieldValue).to.equal(1000)
 
         expect(pageData.errors).to.contain({
           recaptcha: 'You failed the captcha challenge.  Please try again.'

--- a/app/payment-link-v2/confirm/confirm.njk
+++ b/app/payment-link-v2/confirm/confirm.njk
@@ -21,23 +21,30 @@
 
       {% set summaryElementsList = [] %}
       {% for summaryElement in summaryElements %}
-        {% set summaryElementsList = (summaryElementsList.push({
+        
+        {% if summaryElement.changeUrl %}
+          {% set actionSettings = {
+              items: [{
+                href: summaryElement.changeUrl,
+                text: __p('paymentLinksV2.confirm.change'),
+                visuallyHiddenText: summaryElement.summaryLabel
+              }]  
+            }
+          %}
+        {% endif %}
+        
+        {% set summaryElementJson = {
             key: {
               text: summaryElement.summaryLabel
             },
             value: {
               text: summaryElement.summaryValue
             },
-            actions: {
-              items: [
-                {
-                  href: summaryElement.changeUrl,
-                  text: "Change",
-                  visuallyHiddenText: summaryElement.summaryLabel
-                }
-              ]
-            }
-        }), summaryElementsList) %}
+            actions: actionSettings
+          }
+        %}
+
+        {% set summaryElementsList = (summaryElementsList.push(summaryElementJson), summaryElementsList) %}
       {% endfor %}
 
       {{ govukSummaryList({

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -70,13 +70,13 @@
 			"confirmAndContinue": "TODO convert to Welsh - Confirm and continue",
 			"edit": "TODO convert to Welsh - Edit"
 		},
-
     "amount": {
       "enterAmountToPay": "TODO convert to Welsh - Enter amount to pay" 
     },
     "confirm": {
 			"checkYourDetails": "TODO convert to Welsh - Check your details",
-      "totalToPay": "TODO convert to Welsh - Total to pay" 
+      "totalToPay": "TODO convert to Welsh - Total to pay",
+      "Change": "TODO convert to Welsh - Change"
 		},
     "fieldValidation": {
       "enterAnAmountInPounds": "TODO convert to Welsh - Enter an amount in pounds",

--- a/locales/en.json
+++ b/locales/en.json
@@ -75,7 +75,8 @@
 		},
     "confirm": {
 			"checkYourDetails": "Check your details",
-      "totalToPay": "Total to pay" 
+      "totalToPay": "Total to pay",
+      "change": "Change"
 		},
     "fieldValidation": {
       "enterAnAmountInPounds": "Enter an amount in pounds",

--- a/test/cypress/integration/payment-link-v2/confirm.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/confirm.cy.test.js
@@ -31,10 +31,13 @@ describe('Confirm page', () => {
 
       cy.get('[data-cy=summary-list]').get('dt').eq(0).should('contain', 'Total to pay')
       cy.get('[data-cy=summary-list]').get('dd').eq(0).should('contain', '£10.00')
+      cy.get('[data-cy=summary-list]').get('dd').eq(1).should('not.exist')
 
       cy.get('[data-cy=form]').get('#amount').eq(0).should('value', '1000')
+    })
 
-      cy.get('[data-cy=continue-to-payment-button]').should('exist')
+    it('should not display the `Change` amount link', () => {
+      cy.get('[data-cy=summary-list]').get('dd').eq(1).should('not.exist')
     })
   })
 })


### PR DESCRIPTION
- When the product has a `price`
  - Do not display the `change` URL link as the user will not be allowed
    to edit the price.
  - Use the `product.price` when creating the payment -  ignore  the
    `hidden amount form field`.
- Refactor `controller > getSummaryElements`
  - Rename parameter `amount` to `sessionAmount`
  - If there is a product.price, this takes priority
    over the amount stored in the sesson.
  - Stop checking if the `product.price` or `session amount` in multiple
    places.  Check this in 1 place.
- When product has `reference_enabled=true`
  - Only use the reference value from the hidden form field to create
    the payment when this is enabled.
- When creating the payment
  - Use the product.price if specified, otherwise use the value from
    session.
  - If product.reference_enabled=true, then retrieve the reference value
    from the `hidden form reference value` field.
- Update unit tests and Cypress test.
