### PR TITLE
PP-8982 Delete session when redirecting to payment

### DIFF
--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -161,6 +161,7 @@ async function postPage (req, res, next) {
       req.body[HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE]
     )
 
+    paymentLinkSession.deletePaymentLinkSession(req, product.externalId)
     res.redirect(303, payment.links.next.href)
   } catch (error) {
     return next(error)

--- a/app/payment-link-v2/confirm/confirm.controller.test.js
+++ b/app/payment-link-v2/confirm/confirm.controller.test.js
@@ -20,7 +20,8 @@ let req, res
 describe('Confirm Page Controller', () => {
   const mockPaymentLinkSession = {
     getAmount: sinon.stub(),
-    getReference: sinon.stub()
+    getReference: sinon.stub(),
+    deletePaymentLinkSession: sinon.stub()
   }
 
   const mockCaptcha = {
@@ -260,6 +261,7 @@ describe('Confirm Page Controller', () => {
           '1000',
           'a-invoice-number'
         )
+        sinon.assert.calledWith(mockPaymentLinkSession.deletePaymentLinkSession, req, product.externalId)
         sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
       })
 


### PR DESCRIPTION
Delete the payment link session after a payment has been created before
redirecting to the next_url