### PR TITLE
PP-8966 Add Cypress test for resolving details from query params

### DIFF
--- a/test/cypress/integration/payment-link-v2/details-provided-in-query-params.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/details-provided-in-query-params.cy.test.js
@@ -1,0 +1,48 @@
+const productStubs = require('../../stubs/products-stubs')
+const serviceStubs = require('../../stubs/service-stubs')
+
+const gatewayAccountId = 42
+const productExternalId = 'a-product-id'
+const productName = 'Pay for a green waste bin'
+
+describe('Payment link visited with amount and reference provided as query params', () => {
+  beforeEach(() => {
+    cy.task('setupStubs', [
+      productStubs.getProductByExternalIdStub({
+        gateway_account_id: gatewayAccountId,
+        external_id: productExternalId,
+        reference_enabled: true,
+        reference_label: 'Council tax number',
+        price: null,
+        type: 'ADHOC',
+        name: productName,
+        new_payment_link_journey_enabled: true
+      }),
+      serviceStubs.getServiceSuccess({
+        gatewayAccountId: gatewayAccountId
+      })
+    ])
+  })
+
+  it('should show confirm page with details provided in the query params when "Continue" is clicked', () => {
+    cy.visit(`/pay/${productExternalId}?amount=5689&reference=REF123`)
+    cy.get('h1').should('have.text', productName)
+
+    cy.get('[data-cy=button]').click()
+
+    cy.location().should((location) => {
+      expect(location.pathname).to.eq(`/pay/${productExternalId}/confirm`)
+    })
+
+    cy.get('[data-cy=summary-list]').within(() => {
+      cy.get('.govuk-summary-list__row').eq(0).within(() => {
+        cy.get('dt').should('contain', 'Council tax number')
+        cy.get('dd').eq(0).should('contain', 'REF123')
+      })
+      cy.get('.govuk-summary-list__row').eq(1).within(() => {
+        cy.get('dt').should('contain', 'Total to pay')
+        cy.get('dd').eq(0).should('contain', '£56.89')
+      })
+    })
+  })
+})


### PR DESCRIPTION
Add a Cypress tests that checks that when the reference and amount are provided as query params to the payment link, these are stored in the session and the user is then shown them on the confirm page when they click "Continue" on the payment link start page.