### PR TITLE
BAU Categorise CAPTHCA token missing as warning

### DIFF
--- a/app/utils/captcha.js
+++ b/app/utils/captcha.js
@@ -23,7 +23,8 @@ function verifyCAPTCHAEnterpriseVersion (token) {
       return
     }
     if (!token) {
-      reject(new Error('no reCAPTCHA enterprise widget token response provided'))
+      logger.warn('no reCAPTCHA enterprise widget token response provided')
+      resolve(false)
       return
     }
     request.post({
@@ -52,6 +53,8 @@ function verifyCAPTCHAEnterpriseVersion (token) {
             score: body.score,
             reasons: body.reasons
           })
+          resolve(false)
+          return
         }
         resolve(true)
         return


### PR DESCRIPTION
Card scanning attacks that haven't been built for the payment link pages
generally fail to attempt the CAPTCHA challenge when it's enabled. This
will result in a POST request that doesn't have the token provided by
reCAPTCHA v2.

Currently this scenario will thrown an error which is propagated
through alerting tools. As these are generally high volume attacks this
can introduce a lot of noise.

Treat a missing token as a standard CAPTHCA fail blocking the journey,
warn for analytics but don't raise an error.

Nothing should change about the journey as requests will have been blocked
either way -- tests should still pass.