### PR TITLE
PP-9640 Display amount hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ pacts/
 coverage
 *.log
 .env
+mb.pid
 
 # IntelliJ gubbins
 *.iml

--- a/app/models/Product.class.js
+++ b/app/models/Product.class.js
@@ -38,6 +38,7 @@ class Product {
    * @param {string} opts.reference_enabled - when enabled will ask the user to input a reference for the payment
    * @param {string} opts.reference_label - mandatory field that will display when reference is enabled
    * @param {string} opts.reference_hint - optional field that will display when reference is enabled
+   * @param {string} opts.amountHint - optional field that will display when amount is user-provided
    * @param {string} opts.language - the language pages are displayed in for the product
    * @param {Object[]} opts._links - links for the product ('self' to re-GET this product from the server, and 'pay' to create a payment for this product)
    * @param {string} opts._links[].href - url of the link
@@ -59,6 +60,7 @@ class Product {
     this.reference_enabled = opts.reference_enabled
     this.reference_label = opts.reference_label
     this.reference_hint = opts.reference_hint
+    this.amountHint = opts.amount_hint
     this.language = opts.language
     this.requireCaptcha = opts.require_captcha
     this.newPaymentLinkJourneyEnabled = opts.new_payment_link_journey_enabled

--- a/app/payment-link-v2/amount/amount.njk
+++ b/app/payment-link-v2/amount/amount.njk
@@ -40,6 +40,9 @@
           isPageHeading: true,
           attributes: { 'data-cy': 'label' }
         },
+        hint: {
+          html: product.amountHint | striptags(true) | escape | nl2br if product.amountHint else false
+        },
         value: amount,
         prefix: {
           text: "£"

--- a/app/payment-link-v2/confirm/confirm.njk
+++ b/app/payment-link-v2/confirm/confirm.njk
@@ -27,7 +27,7 @@
            <input id="reference-value" name="reference-value" type="hidden" value="{{ sessionReferenceNumber }}" />
         {% endif %}
 
-        <input id="amount" name="reference-value" type="hidden" value="{{ amountAsPence }}" />
+        <input id="amount" name="amount" type="hidden" value="{{ amountAsPence }}" />
 
         {% if product.requireCaptcha %}
           <div class="g-recaptcha govuk-!-margin-bottom-5" data-sitekey="{{ GOOGLE_RECAPTCHA_SITE_KEY }}"></div>

--- a/app/payment-link-v2/reference/reference.njk
+++ b/app/payment-link-v2/reference/reference.njk
@@ -47,7 +47,7 @@
           }
         },
         hint: {
-          text: product.reference_hint
+          html: product.reference_hint | striptags(true) | escape | nl2br if product.reference_hint else false
         },
         value: reference,
         classes: "govuk-input--width-21",

--- a/test/cypress/integration/payment-link-v2/amount.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/amount.cy.test.js
@@ -14,7 +14,8 @@ describe('Amount page', () => {
           external_id: productExternalId,
           reference_enabled: false,
           reference_label: 'invoice number',
-          type: 'ADHOC'
+          type: 'ADHOC',
+          amount_hint: 'Find it somewhere'
         }),
         serviceStubs.getServiceSuccess({
           gatewayAccountId: gatewayAccountId,
@@ -31,6 +32,7 @@ describe('Amount page', () => {
 
       cy.get('[data-cy=back-link]').should('have.attr', 'href', '/pay/a-product-id')
       cy.get('[data-cy=label]').should('contain', 'Enter amount to pay')
+      cy.get('#payment-amount-hint').should('contain', 'Find it somewhere')
       cy.get('[data-cy=button]').should('exist')
     })
 

--- a/test/fixtures/product.fixtures.js
+++ b/test/fixtures/product.fixtures.js
@@ -50,6 +50,7 @@ module.exports = {
     if (opts.service_name_path) data.service_name_path = opts.service_name_path
     if (opts.product_name_path) data.product_name_path = opts.product_name_path
     if (opts.require_captcha !== undefined) data.require_captcha = opts.require_captcha
+    if (opts.amount_hint) data.amount_hint = opts.amount_hint
     if (!data._links) {
       data._links = [{
         href: `http://products.url/v1/api/products/${data.external_id}`,


### PR DESCRIPTION
If the payment link has an `amount_hint` specified, display it as the hint text on the amount page.