### PR TITLE
PP-8966 Don't show change links when details provided by query params

### DIFF
--- a/app/controllers/friendly-url-redirect.controller.js
+++ b/app/controllers/friendly-url-redirect.controller.js
@@ -7,6 +7,7 @@ const productsClient = require('../services/clients/products.client')
 const { renderErrorView } = require('../utils/response')
 const replaceParamsInPath = require('../utils/replace-params-in-path')
 const paths = require('../paths')
+const { deletePaymentLinkSession } = require('../payment-link-v2/utils/payment-link-session')
 
 // Constants
 const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
@@ -19,6 +20,11 @@ module.exports = async function redirectToProduct(req, res) {
       pathname: replaceParamsInPath(paths.pay.product, product.externalId),
       query: req.query
     })
+    // Clear the payment link session - we want to do this as we don't allow users to change the
+    // values provided in query parameters by the service. The service may send them a link for the
+    // same product without the query parameters, and in this case we do want to allow them to enter
+    // values
+    deletePaymentLinkSession(req, product.externalId)
     logger.info(`Redirecting to ${payUrl}`)
     return res.redirect(payUrl)
   } catch (err) {

--- a/app/controllers/pre-payment.controller.js
+++ b/app/controllers/pre-payment.controller.js
@@ -41,11 +41,11 @@ module.exports = (req, res) => {
         }
         let validReferenceProvided, validAmountProvided
         if (product.reference_enabled && reference && validateReference(reference).valid) {
-          paymentLinkSession.setReference(req, product.externalId, reference)
+          paymentLinkSession.setReference(req, product.externalId, reference, true)
           validReferenceProvided = true
         }
         if (!product.price && amount && validateAmount(amount).valid) {
-          paymentLinkSession.setAmount(req, product.externalId, amount)
+          paymentLinkSession.setAmount(req, product.externalId, amount, true)
           validAmountProvided = true
         }
         const continueUrl = getContinueUrlForNewPaymentLinkJourney(product, validReferenceProvided, validAmountProvided)

--- a/app/controllers/pre-payment.controller.test.js
+++ b/app/controllers/pre-payment.controller.test.js
@@ -95,7 +95,9 @@ describe('Pre payment controller', () => {
             expect(req.session).to.have.property(product.externalId)
             expect(req.session[product.externalId]).to.deep.equal({
               reference: queryParamReference,
-              amount: queryParamAmount
+              amount: queryParamAmount,
+              referenceProvidedByQueryParams: true,
+              amountProvidedByQueryParams: true
             })
 
             sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/confirm` })
@@ -118,7 +120,8 @@ describe('Pre payment controller', () => {
               expect(req).to.have.property('session')
               expect(req.session).to.have.property(product.externalId)
               expect(req.session[product.externalId]).to.deep.equal({
-                amount: queryParamAmount
+                amount: queryParamAmount,
+                amountProvidedByQueryParams: true
               })
 
               sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/confirm` })
@@ -142,7 +145,8 @@ describe('Pre payment controller', () => {
               expect(req).to.have.property('session')
               expect(req.session).to.have.property(product.externalId)
               expect(req.session[product.externalId]).to.deep.equal({
-                reference: queryParamReference
+                reference: queryParamReference,
+                referenceProvidedByQueryParams: true
               })
 
               sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/confirm` })
@@ -168,6 +172,7 @@ describe('Pre payment controller', () => {
             expect(req.session).to.have.property(product.externalId)
             expect(req.session[product.externalId]).to.deep.equal({
               reference: queryParamReference,
+              referenceProvidedByQueryParams: true
             })
 
             sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/amount` })
@@ -208,6 +213,7 @@ describe('Pre payment controller', () => {
             expect(req.session).to.have.property(product.externalId)
             expect(req.session[product.externalId]).to.deep.equal({
               amount: queryParamAmount,
+              amountProvidedByQueryParams: true
             })
 
             sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/reference` })

--- a/app/payment-link-v2/amount/amount.controller.js
+++ b/app/payment-link-v2/amount/amount.controller.js
@@ -35,8 +35,8 @@ function getPage (req, res, next) {
   }
 
   const sessionAmount = paymentLinkSession.getAmount(req, product.externalId)
-
-  data.backLinkHref = getBackLinkUrl(sessionAmount, product)
+  const referenceProvidedByQueryParams = paymentLinkSession.getReferenceProvidedByQueryParams(req, product.externalId)
+  data.backLinkHref = getBackLinkUrl(sessionAmount, product, referenceProvidedByQueryParams)
 
   if (sessionAmount) {
     data.amount = (parseFloat(sessionAmount) / 100).toFixed(2)
@@ -52,7 +52,8 @@ function postPage (req, res, next) {
   const product = req.product
 
   const sessionAmount = paymentLinkSession.getAmount(req, product.externalId)
-  const backLinkHref = getBackLinkUrl(sessionAmount, product)
+  const referenceProvidedByQueryParams = paymentLinkSession.getReferenceProvidedByQueryParams(req, product.externalId)
+  const backLinkHref = getBackLinkUrl(sessionAmount, product, referenceProvidedByQueryParams)
 
   const data = {
     productExternalId: product.externalId,

--- a/app/payment-link-v2/amount/get-back-link-url.js
+++ b/app/payment-link-v2/amount/get-back-link-url.js
@@ -3,10 +3,10 @@
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
 const { paymentLinksV2 } = require('../../paths')
 
-module.exports = function getBackLinkUrl (amount, product) {
+module.exports = function getBackLinkUrl (amount, product, referenceProvidedByQueryParams) {
   if (amount) {
     return replaceParamsInPath(paymentLinksV2.confirm, product.externalId)
-  } else if (product.reference_enabled) {
+  } else if (product.reference_enabled && !referenceProvidedByQueryParams) {
     return replaceParamsInPath(paymentLinksV2.reference, product.externalId)
   } else {
     return replaceParamsInPath(paymentLinksV2.product, product.externalId)

--- a/app/payment-link-v2/amount/get-back-link-url.test.js
+++ b/app/payment-link-v2/amount/get-back-link-url.test.js
@@ -31,6 +31,19 @@ describe('getBackLinkUrl', () => {
     expect(url).to.equal('/pay/123/reference')
   })
 
+  it('when there is NO `amount` and `reference_enabled=true`, but the reference was provided by the query params then it should return the `product` page URL', () => {
+    const amount = 0
+
+    const product = {
+      externalId: 123,
+      reference_enabled: true
+    }
+
+    const url = getBackLinkUrl(amount, product, true)
+
+    expect(url).to.equal('/pay/123')
+  })
+
   it('when there is NO `amount` and `reference_enabled=false`, then it should return the `product` page URL', () => {
     const amount = 0
 

--- a/app/payment-link-v2/confirm/_summary-list.njk
+++ b/app/payment-link-v2/confirm/_summary-list.njk
@@ -2,6 +2,17 @@
 
 {% set summaryElementsList = [] %}
 
+{% if canChangeReference %}
+  {% set referenceAction = {
+      items: [{
+        href: referenceChangeUrl,
+        text: __p('paymentLinksV2.confirm.change'),
+        visuallyHiddenText: productReferenceLabel
+      }]  
+    }
+  %}
+{% endif %}
+
 {% if productReferenceLabel %}
   {% set referenceSummaryElement = {
     key: {
@@ -10,20 +21,14 @@
     value: {
       text: sessionReferenceNumber
     },
-    actions: {
-        items: [{
-          href: referenceChangeUrl,
-          text: __p('paymentLinksV2.confirm.change'),
-          visuallyHiddenText: productReferenceLabel
-        }]  
-      } 
+    actions: referenceAction
   } %}
 
   {% set summaryElementsList = (summaryElementsList.push(referenceSummaryElement), summaryElementsList) %}
 {% endif %}
 
-{% if sessionAmount %}
-  {% set amountActionText = {
+{% if canChangeAmount %}
+  {% set amountAction = {
       items: [{
         href: amountChangeUrl,
         text: __p('paymentLinksV2.confirm.change'),
@@ -40,7 +45,7 @@
     value: {
       text: amountAsGbp
     },
-    actions: amountActionText 
+    actions: amountAction
   } 
 %}
 

--- a/app/payment-link-v2/utils/payment-link-session.js
+++ b/app/payment-link-v2/utils/payment-link-session.js
@@ -5,28 +5,44 @@ const { getSessionCookieName } = require('../../utils/cookie')
 
 const REFERENCE_KEY = 'reference'
 const AMOUNT_KEY = 'amount'
+const REFERENCE_PROVIDED_BY_QUERY_PARAMS_KEY = 'referenceProvidedByQueryParams'
+const AMOUNT_PROVIDED_BY_QUERY_PARAMS_KEY = 'amountProvidedByQueryParams'
 
-function cookieIndex (key, productExternalId) {
+function cookieIndex(key, productExternalId) {
   return `${getSessionCookieName()}.${productExternalId}.${key}`
 }
 
-function getReference (req, productExternalId) {
+function getReference(req, productExternalId) {
   return lodash.get(req, cookieIndex(REFERENCE_KEY, productExternalId))
 }
 
-function setReference (req, productExternalId, reference) {
+function setReference(req, productExternalId, reference, providedByQueryParams = false) {
   lodash.set(req, cookieIndex(REFERENCE_KEY, productExternalId), reference)
+  if (providedByQueryParams) {
+    lodash.set(req, cookieIndex(REFERENCE_PROVIDED_BY_QUERY_PARAMS_KEY, productExternalId), true)
+  }
 }
 
-function getAmount (req, productExternalId) {
+function getAmount(req, productExternalId) {
   return lodash.get(req, cookieIndex(AMOUNT_KEY, productExternalId))
 }
 
-function setAmount (req, productExternalId, amount) {
+function setAmount(req, productExternalId, amount, providedByQueryParams = false) {
   lodash.set(req, cookieIndex(AMOUNT_KEY, productExternalId), amount)
+  if (providedByQueryParams) {
+    lodash.set(req, cookieIndex(AMOUNT_PROVIDED_BY_QUERY_PARAMS_KEY, productExternalId), true)
+  }
 }
 
-function deletePaymentLinkSession (req, productExternalId) {
+function getReferenceProvidedByQueryParams(req, productExternalId) {
+  return lodash.get(req, cookieIndex(REFERENCE_PROVIDED_BY_QUERY_PARAMS_KEY, productExternalId), false)
+}
+
+function getAmountProvidedByQueryParams(req, productExternalId) {
+  return lodash.get(req, cookieIndex(AMOUNT_PROVIDED_BY_QUERY_PARAMS_KEY, productExternalId), false)
+}
+
+function deletePaymentLinkSession(req, productExternalId) {
   lodash.unset(req, `${getSessionCookieName()}.${productExternalId}`)
 }
 
@@ -35,5 +51,7 @@ module.exports = {
   setReference,
   getAmount,
   setAmount,
+  getReferenceProvidedByQueryParams,
+  getAmountProvidedByQueryParams,
   deletePaymentLinkSession
 }

--- a/app/payment-link-v2/utils/payment-link-session.test.js
+++ b/app/payment-link-v2/utils/payment-link-session.test.js
@@ -32,8 +32,16 @@ describe('Payment link session utilities', () => {
       const req = {}
       paymentLinkSession.setReference(req, productExternalId, reference)
 
-      const sessionRef = paymentLinkSession.getReference(req, productExternalId)
-      expect(sessionRef).to.equal(reference)
+      expect(paymentLinkSession.getReference(req, productExternalId)).to.equal(reference)
+      expect(paymentLinkSession.getReferenceProvidedByQueryParams(req, productExternalId)).to.equal(false)
+    })
+
+    it('should set the reference and referenceProvidedByQueryParams', () => {
+      const req = {}
+      paymentLinkSession.setReference(req, productExternalId, reference, true)
+
+      expect(paymentLinkSession.getReference(req, productExternalId)).to.equal(reference)
+      expect(paymentLinkSession.getReferenceProvidedByQueryParams(req, productExternalId)).to.equal(true)
     })
 
     it('should override existing reference', () => {
@@ -76,9 +84,18 @@ describe('Payment link session utilities', () => {
       const req = {}
       paymentLinkSession.setAmount(req, productExternalId, amount)
 
-      const sessionAmount = paymentLinkSession.getAmount(req, productExternalId)
-      expect(sessionAmount).to.equal(amount)
+      expect(paymentLinkSession.getAmount(req, productExternalId)).to.equal(amount)
+      expect(paymentLinkSession.getAmountProvidedByQueryParams(req, productExternalId)).to.equal(false)
     })
+
+    it('should set the amount and amountProvidedByQueryParams', () => {
+      const req = {}
+      paymentLinkSession.setAmount(req, productExternalId, amount, true)
+      
+      expect(paymentLinkSession.getAmount(req, productExternalId)).to.equal(amount)
+      expect(paymentLinkSession.getAmountProvidedByQueryParams(req, productExternalId)).to.equal(true)
+    })
+
 
     it('should override existing amount', () => {
       const req = {

--- a/test/cypress/integration/payment-link-v2/details-provided-in-query-params.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/details-provided-in-query-params.cy.test.js
@@ -45,10 +45,14 @@ describe('Payment link visited with amount and reference provided as query param
       cy.get('.govuk-summary-list__row').eq(0).within(() => {
         cy.get('dt').should('contain', 'Council tax number')
         cy.get('dd').eq(0).should('contain', 'REF123')
+        // should be no change link
+        cy.get('dd').eq(1).should('not.exist')
       })
       cy.get('.govuk-summary-list__row').eq(1).within(() => {
         cy.get('dt').should('contain', 'Total to pay')
         cy.get('dd').eq(0).should('contain', '£56.89')
+        // should be no change link
+        cy.get('dd').eq(1).should('not.exist')
       })
     })
   })


### PR DESCRIPTION
When the reference and/or amount are provided in query params for the link, do not allow the user to change these values.

Display them on the confirm page, but without the change link.

Change the back links on pages so we skip the pages where the value has been provided by query params. The only page currently affected by this is the amount page, which shouldn't link back to the reference page if the reference was provided by the query params.