### PR TITLE
PP-8942 Confirm Page - Cypress tests

### DIFF
--- a/app/payment-link-v2/confirm/confirm.njk
+++ b/app/payment-link-v2/confirm/confirm.njk
@@ -29,7 +29,7 @@
 
         <input id="amount" name="amount" type="hidden" value="{{ amountAsPence }}" />
 
-        {% if product.requireCaptcha %}
+        {% if requireCaptcha %}
           <div class="g-recaptcha govuk-!-margin-bottom-5" data-sitekey="{{ GOOGLE_RECAPTCHA_SITE_KEY }}"></div>
         {% endif %}
 


### PR DESCRIPTION
- Fix Cypress tests.
  - Update to use the Cypress `within` method - to correctly search for elements
    with a parent element.
  - Do not have multiple IT statements within a single DESCRIBE block -
    as this is the best practise and prevents testing issues.
  - Add tests to check for the RECAPTCHA div element when  product.require_recaptcha=true.