### PR TITLE
PP-9476 Fix back links

### DIFF
--- a/app/payment-link-v2/amount/amount.controller.js
+++ b/app/payment-link-v2/amount/amount.controller.js
@@ -24,6 +24,7 @@ function validateAmountFormValue (amount, res) {
 
 function getPage (req, res, next) {
   const product = req.product
+  const { change } = req.query || {}
 
   const data = {
     productExternalId: product.externalId,
@@ -36,7 +37,7 @@ function getPage (req, res, next) {
 
   const sessionAmount = paymentLinkSession.getAmount(req, product.externalId)
   const referenceProvidedByQueryParams = paymentLinkSession.getReferenceProvidedByQueryParams(req, product.externalId)
-  data.backLinkHref = getBackLinkUrl(sessionAmount, product, referenceProvidedByQueryParams)
+  data.backLinkHref = getBackLinkUrl(change, product, referenceProvidedByQueryParams)
 
   if (sessionAmount) {
     data.amount = (parseFloat(sessionAmount) / 100).toFixed(2)
@@ -47,13 +48,13 @@ function getPage (req, res, next) {
 
 function postPage (req, res, next) {
   const paymentAmount = lodash.get(req.body, PAYMENT_AMOUNT, '')
+  const { change } = req.query || {}
   const errors = validateAmountFormValue(paymentAmount, res)
 
   const product = req.product
 
-  const sessionAmount = paymentLinkSession.getAmount(req, product.externalId)
   const referenceProvidedByQueryParams = paymentLinkSession.getReferenceProvidedByQueryParams(req, product.externalId)
-  const backLinkHref = getBackLinkUrl(sessionAmount, product, referenceProvidedByQueryParams)
+  const backLinkHref = getBackLinkUrl(change, product, referenceProvidedByQueryParams)
 
   const data = {
     productExternalId: product.externalId,

--- a/app/payment-link-v2/amount/get-back-link-url.js
+++ b/app/payment-link-v2/amount/get-back-link-url.js
@@ -3,8 +3,8 @@
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
 const { paymentLinksV2 } = require('../../paths')
 
-module.exports = function getBackLinkUrl (amount, product, referenceProvidedByQueryParams) {
-  if (amount) {
+module.exports = function getBackLinkUrl (isEditing, product, referenceProvidedByQueryParams) {
+  if (isEditing) {
     return replaceParamsInPath(paymentLinksV2.confirm, product.externalId)
   } else if (product.reference_enabled && !referenceProvidedByQueryParams) {
     return replaceParamsInPath(paymentLinksV2.reference, product.externalId)

--- a/app/payment-link-v2/confirm/_summary-list.njk
+++ b/app/payment-link-v2/confirm/_summary-list.njk
@@ -5,7 +5,7 @@
 {% if canChangeReference %}
   {% set referenceAction = {
       items: [{
-        href: referenceChangeUrl,
+        href: replaceParamsInPath(routes.paymentLinksV2.reference, product.externalId) + "?change=true",
         text: __p('paymentLinksV2.confirm.change'),
         visuallyHiddenText: productReferenceLabel
       }]  
@@ -30,7 +30,7 @@
 {% if canChangeAmount %}
   {% set amountAction = {
       items: [{
-        href: amountChangeUrl,
+        href: replaceParamsInPath(routes.paymentLinksV2.amount, product.externalId) + "?change=true",
         text: __p('paymentLinksV2.confirm.change'),
         visuallyHiddenText: summaryElement.summaryLabel
       }]  

--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -55,8 +55,6 @@ function setupPageData (product, sessionReferenceNumber, sessionAmount, referenc
     sessionReferenceNumber,
     canChangeAmount,
     canChangeReference,
-    referenceChangeUrl: replaceParamsInPath(paths.paymentLinksV2.reference, product.externalId),
-    amountChangeUrl: replaceParamsInPath(paths.paymentLinksV2.amount, product.externalId),
     requireCaptcha: product.requireCaptcha
   }
 }

--- a/app/payment-link-v2/confirm/confirm.controller.test.js
+++ b/app/payment-link-v2/confirm/confirm.controller.test.js
@@ -87,8 +87,6 @@ describe('Confirm Page Controller', () => {
         expect(pageData.sessionAmount).to.equal(1050)
         expect(pageData.amountAsPence).to.equal(1050)
         expect(pageData.amountAsGbp).to.equal('£10.50')
-        expect(pageData.referenceChangeUrl).to.equal('/pay/an-external-id/reference')
-        expect(pageData.amountChangeUrl).to.equal('/pay/an-external-id/amount')
       })
 
       it('when there is no amount in the session, then it should redirect to the start page', () => {
@@ -172,8 +170,6 @@ describe('Confirm Page Controller', () => {
         expect(pageData.sessionAmount).to.equal(undefined)
         expect(pageData.amountAsPence).to.equal(1000)
         expect(pageData.amountAsGbp).to.equal('£10.00')
-        expect(pageData.referenceChangeUrl).to.equal('/pay/an-external-id/reference')
-        expect(pageData.amountChangeUrl).to.equal('/pay/an-external-id/amount')
       })
 
       it('when there is no reference in the session then it should redirect to the start page', () => {
@@ -233,8 +229,6 @@ describe('Confirm Page Controller', () => {
         expect(pageData.sessionAmount).to.equal('1050')
         expect(pageData.amountAsPence).to.equal('1050')
         expect(pageData.amountAsGbp).to.equal('£10.50')
-        expect(pageData.referenceChangeUrl).to.equal('/pay/an-external-id/reference')
-        expect(pageData.amountChangeUrl).to.equal('/pay/an-external-id/amount')
       })
 
       it('when there is no amount in the session, then it should redirect to the start page', () => {
@@ -608,8 +602,6 @@ describe('Confirm Page Controller', () => {
         expect(pageData.sessionAmount).to.equal(undefined)
         expect(pageData.amountAsPence).to.equal(1000)
         expect(pageData.amountAsGbp).to.equal('£10.00')
-        expect(pageData.referenceChangeUrl).to.equal('/pay/an-external-id/reference')
-        expect(pageData.amountChangeUrl).to.equal('/pay/an-external-id/amount')
         expect(pageData.requireCaptcha).to.equal(true)
 
         expect(pageData.errors).to.contain({

--- a/app/payment-link-v2/reference/get-back-link-url.js
+++ b/app/payment-link-v2/reference/get-back-link-url.js
@@ -3,8 +3,8 @@
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
 const { paymentLinksV2 } = require('../../paths')
 
-module.exports = function getBackLinkUrl (reference, product) {
-  if (reference) {
+module.exports = function getBackLinkUrl (isEditing, product) {
+  if (isEditing) {
     return replaceParamsInPath(paymentLinksV2.confirm, product.externalId)
   } else {
     return replaceParamsInPath(paymentLinksV2.product, product.externalId)

--- a/app/payment-link-v2/reference/reference.controller.test.js
+++ b/app/payment-link-v2/reference/reference.controller.test.js
@@ -64,12 +64,14 @@ describe('Reference Page Controller', () => {
         expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
       })
 
-      it('when the reference is in the session, then it should display the reference page ' +
-        'and set the back link to the CONFIRM page', () => {
+      it('when the change query parameter is present, should set the back link to the CONFIRM page', () => {
         req = {
           correlationId: '123',
           product,
-          service
+          service,
+          query: {
+            change: 'true'
+          }
         }
         res = {}
 
@@ -139,21 +141,21 @@ describe('Reference Page Controller', () => {
         sinon.assert.calledWith(res.redirect, '/pay/an-external-id/amount')
       })
 
-      it('when an valid reference is entered and an AMOUNT is already saved to the session, it should  ' +
-      'redirect to the CONFIRM page', () => {
+      it('when an valid reference is entered and the change query param is present, should redirect to the confirm page', () => {
         req = {
           correlationId: '123',
           product,
           body: {
             'payment-reference': 'valid reference'
+          },
+          query: {
+            change: 'true'
           }
         }
 
         res = {
           redirect: sinon.spy()
         }
-
-        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1000)
 
         controller.postPage(req, res)
 
@@ -257,13 +259,16 @@ describe('Reference Page Controller', () => {
         expect(pageData.errors['payment-reference']).to.equal('Invoice number must be less than or equal to 50 characters')
       })
 
-      it('when an invalid reference is entered and a reference is already saved to the session, it should display an error ' +
+      it('when an invalid reference is entered and the change query parameter is present, it should display an error ' +
       'message and set the back link to the CONFIRM page', () => {
         req = {
           correlationId: '123',
           product,
           body: {
             'payment-reference': 'reference with invalid characters <>'
+          },
+          query: {
+            change: 'true'
           }
         }
 
@@ -273,8 +278,6 @@ describe('Reference Page Controller', () => {
             __p: sinon.stub()
           }
         }
-
-        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('a valid reference')
 
         res.locals.__p.withArgs('paymentLinksV2.fieldValidation.referenceCantUseInvalidChars').returns('%s can’t contain any of the following characters < > ; : ` ( ) " \' = &#124; "," ~ [ ]')
 

--- a/server.js
+++ b/server.js
@@ -25,6 +25,7 @@ const i18nConfig = require('./config/i18n')
 const logger = require('./app/utils/logger')(__filename)
 const loggingMiddleware = require('./app/middleware/logging-middleware')
 const Sentry = require('./app/utils/sentry.js').initialiseSentry()
+const replaceParamsInPath = require('./app/utils/replace-params-in-path')
 
 // Global constants
 const JAVASCRIPT_PATH = staticify.getVersionedPath('/js/application.min.js')
@@ -64,6 +65,7 @@ function initialiseGlobalMiddleware (app) {
     res.locals.analyticsTrackingId = ANALYTICS_TRACKING_ID
     res.locals.GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION = process.env.GOOGLE_RECAPTCHA_USE_ENTERPRISE_VERSION === 'true'
     res.locals.GOOGLE_RECAPTCHA_SITE_KEY = process.env.GOOGLE_RECAPTCHA_SITE_KEY
+    res.locals.replaceParamsInPath = replaceParamsInPath
     noCache(res)
     next()
   })

--- a/test/cypress/integration/payment-link-v2/confirm.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/confirm.cy.test.js
@@ -19,7 +19,7 @@ function checkReferenceRow (rowNumber, shouldExist) {
     cy.get('dt').eq(0).should('contain', 'invoice number')
     cy.get('dd').eq(0).should('contain', 'a-invoice-number')
     cy.get('dd').eq(1).get('.govuk-link')
-      .should('have.attr', 'href', '/pay/a-product-id/reference')
+      .should('have.attr', 'href', '/pay/a-product-id/reference?change=true')
       .should('contain', 'Change')
   })
 }
@@ -39,7 +39,7 @@ function checkChangeAmountLink (rowNumber, shouldExist) {
   if (shouldExist) {
     changeAmountLink.within(() => {
       cy.get('dd').eq(1).get('.govuk-link')
-        .should('have.attr', 'href', '/pay/a-product-id/amount')
+        .should('have.attr', 'href', '/pay/a-product-id/amount?change=true')
         .should('contain', 'Change')
     })
   } else {


### PR DESCRIPTION
Fix the back links to make sure that they only ever link to the confirm page when the user has clicked a change link on the confirm page.
Achieve this by adding a 'change' query parameter to the links from the confirm page and use the value of this to determine the URL for the back link.

Use the 'change' query parameter to decide whether the 'Continue' button on the reference page should redirect to the confirm page, rather than whether an amount is in the session.

These changes will allow us to add a back link to the confirm page which will allow the user to step back through the entire journey.