### PR TITLE
PP-9476 Add back link on confirm page

### DIFF
--- a/app/payment-link-v2/amount/amount.njk
+++ b/app/payment-link-v2/amount/amount.njk
@@ -8,15 +8,19 @@
   {{ __p('paymentLinksV2.amount.enterAmountToPay') }} - {{ productName }}
 {% endblock %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref,
+    attributes: {
+      'data-cy': 'back-link'
+    }
+  }) }}
+{% endblock %}
+
 {% block contentBody %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    {{ govukBackLink({
-      text: "Back",
-      href: backLinkHref,
-      attributes: { 'data-cy': 'back-link' }
-    }) }}
-
     {{ errorSummary ({
       errors: errors,
       hrefs: {

--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -14,6 +14,16 @@ const HIDDEN_FORM_FIELD_ID_AMOUNT = 'amount'
 const GOOGLE_RECAPTCHA_FORM_NAME = 'g-recaptcha-response'
 const ERROR_KEY_RECAPTCHA = 'recaptcha'
 
+function getBackLinkUrl(product, referenceProvidedByQueryParams, amountProvidedByQueryParams) {
+  if (!product.price && !amountProvidedByQueryParams) {
+    return replaceParamsInPath(paths.paymentLinksV2.amount, product.externalId)
+  } else if (product.reference_enabled && !referenceProvidedByQueryParams) {
+    return replaceParamsInPath(paths.paymentLinksV2.reference, product.externalId)
+  } else {
+    return replaceParamsInPath(paths.pay.product, product.externalId)
+  }
+}
+
 async function validateRecaptcha (
   googleRecaptchaFormValue,
   translationMethod
@@ -43,7 +53,8 @@ function setupPageData (product, sessionReferenceNumber, sessionAmount, referenc
   const amountTo2DecimalPoint = (parseFloat(amountAsPence) / 100).toFixed(2)
   const amountAsGbp = Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(amountTo2DecimalPoint)
   const canChangeAmount = !product.price && !amountProvidedByQueryParams
-  const canChangeReference = !referenceProvidedByQueryParams
+  const canChangeReference = product.reference_enabled && !referenceProvidedByQueryParams
+  const backLinkHref = getBackLinkUrl(product, referenceProvidedByQueryParams, amountProvidedByQueryParams)
 
   return {
     productExternalId: product.externalId,
@@ -55,7 +66,8 @@ function setupPageData (product, sessionReferenceNumber, sessionAmount, referenc
     sessionReferenceNumber,
     canChangeAmount,
     canChangeReference,
-    requireCaptcha: product.requireCaptcha
+    requireCaptcha: product.requireCaptcha,
+    backLinkHref
   }
 }
 

--- a/app/payment-link-v2/confirm/confirm.controller.test.js
+++ b/app/payment-link-v2/confirm/confirm.controller.test.js
@@ -20,6 +20,8 @@ describe('Confirm Page Controller', () => {
   const mockPaymentLinkSession = {
     getAmount: sinon.stub(),
     getReference: sinon.stub(),
+    getReferenceProvidedByQueryParams: sinon.stub(),
+    getAmountProvidedByQueryParams: sinon.stub(),
     deletePaymentLinkSession: sinon.stub()
   }
 
@@ -59,35 +61,39 @@ describe('Confirm Page Controller', () => {
         price: null
       }))
 
-      it('then it should update the page data and display the confirm page', () => {
-        req = {
-          correlationId: '123',
-          product,
-          service
-        }
-        res = {
-          locals: {
-            __p: sinon.stub()
+      it('then it should display the confirm page with the reference and amount from the session and ' +
+        'set the back link to the amount page', () => {
+          req = {
+            correlationId: '123',
+            product,
+            service
           }
-        }
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
+          }
 
-        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
-        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1050)
+          mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
+          mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1050)
 
-        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
 
-        controller.getPage(req, res)
+          controller.getPage(req, res)
 
-        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
 
-        const pageData = mockResponses.response.args[0][3]
+          const pageData = mockResponses.response.args[0][3]
 
-        expect(pageData.productReferenceLabel).to.equal('invoice number')
-        expect(pageData.sessionReferenceNumber).to.equal('test invoice number')
-        expect(pageData.sessionAmount).to.equal(1050)
-        expect(pageData.amountAsPence).to.equal(1050)
-        expect(pageData.amountAsGbp).to.equal('£10.50')
-      })
+          expect(pageData.productReferenceLabel).to.equal('invoice number')
+          expect(pageData.sessionReferenceNumber).to.equal('test invoice number')
+          expect(pageData.sessionAmount).to.equal(1050)
+          expect(pageData.amountAsPence).to.equal(1050)
+          expect(pageData.amountAsGbp).to.equal('£10.50')
+          expect(pageData.canChangeAmount).to.equal(true)
+          expect(pageData.canChangeReference).to.equal(true)
+          expect(pageData.backLinkHref).to.equal('/pay/an-external-id/amount')
+        })
 
       it('when there is no amount in the session, then it should redirect to the start page', () => {
         req = {
@@ -111,26 +117,116 @@ describe('Confirm Page Controller', () => {
       })
 
       it('when there is an amount in the session and there is no reference in the session, ' +
-      'then it should redirect to the start page', () => {
-        req = {
-          correlationId: '123',
-          product,
-          service
-        }
-        res = {
-          redirect: sinon.stub(),
-          locals: {
-            __p: sinon.stub()
+        'then it should redirect to the start page', () => {
+          req = {
+            correlationId: '123',
+            product,
+            service
           }
-        }
+          res = {
+            redirect: sinon.stub(),
+            locals: {
+              __p: sinon.stub()
+            }
+          }
 
-        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1000)
-        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns(null)
+          mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1000)
+          mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns(null)
 
-        const next = sinon.spy()
-        controller.getPage(req, res, next)
+          const next = sinon.spy()
+          controller.getPage(req, res, next)
 
-        sinon.assert.calledWith(res.redirect, '/pay/an-external-id')
+          sinon.assert.calledWith(res.redirect, '/pay/an-external-id')
+        })
+
+      describe('when the reference and amount were both set by query parameters', () => {
+        it('should set canChangeReference and canChangeAmount to false and the back link to the start page', () => {
+          req = {
+            correlationId: '123',
+            product,
+            service
+          }
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
+          }
+
+          mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
+          mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1050)
+          mockPaymentLinkSession.getReferenceProvidedByQueryParams.withArgs(req, product.externalId).returns(true)
+          mockPaymentLinkSession.getAmountProvidedByQueryParams.withArgs(req, product.externalId).returns(true)
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+          controller.getPage(req, res)
+
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          const pageData = mockResponses.response.args[0][3]
+
+          expect(pageData.canChangeAmount).to.equal(false)
+          expect(pageData.canChangeReference).to.equal(false)
+          expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
+        })
+      })
+
+      describe('when only the amount was set by query parameters', () => {
+        it('should set canChangeAmount to false and the back link to the reference page', () => {
+          req = {
+            correlationId: '123',
+            product,
+            service
+          }
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
+          }
+
+          mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
+          mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1050)
+          mockPaymentLinkSession.getReferenceProvidedByQueryParams.withArgs(req, product.externalId).returns(false)
+          mockPaymentLinkSession.getAmountProvidedByQueryParams.withArgs(req, product.externalId).returns(true)
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+          controller.getPage(req, res)
+
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          const pageData = mockResponses.response.args[0][3]
+
+          expect(pageData.canChangeAmount).to.equal(false)
+          expect(pageData.canChangeReference).to.equal(true)
+          expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
+        })
+      })
+
+      describe('when only the reference was set by query parameters', () => {
+        it('should set canChangeReference to false and the back link to the amount page', () => {
+          req = {
+            correlationId: '123',
+            product,
+            service
+          }
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
+          }
+
+          mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
+          mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns(1050)
+          mockPaymentLinkSession.getReferenceProvidedByQueryParams.withArgs(req, product.externalId).returns(true)
+          mockPaymentLinkSession.getAmountProvidedByQueryParams.withArgs(req, product.externalId).returns(false)
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+          controller.getPage(req, res)
+
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          const pageData = mockResponses.response.args[0][3]
+
+          expect(pageData.canChangeAmount).to.equal(true)
+          expect(pageData.canChangeReference).to.equal(false)
+          expect(pageData.backLinkHref).to.equal('/pay/an-external-id/amount')
+        })
       })
     })
 
@@ -142,35 +238,38 @@ describe('Confirm Page Controller', () => {
         price: 1000
       }))
 
-      it('when there is a reference in a session, then it should update the page data with the `product.price` and display ' +
-      'the confirm page', () => {
-        req = {
-          correlationId: '123',
-          product,
-          service
-        }
-        res = {
-          locals: {
-            __p: sinon.stub()
+      it('when there is a reference in a session, should set the amount to the `product.price` the ' +
+        'back link to the reference page', () => {
+          req = {
+            correlationId: '123',
+            product,
+            service
           }
-        }
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
+          }
 
-        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
+          mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
 
-        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
 
-        controller.getPage(req, res)
+          controller.getPage(req, res)
 
-        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
 
-        const pageData = mockResponses.response.args[0][3]
+          const pageData = mockResponses.response.args[0][3]
 
-        expect(pageData.productReferenceLabel).to.equal('invoice number')
-        expect(pageData.sessionReferenceNumber).to.equal('test invoice number')
-        expect(pageData.sessionAmount).to.equal(undefined)
-        expect(pageData.amountAsPence).to.equal(1000)
-        expect(pageData.amountAsGbp).to.equal('£10.00')
-      })
+          expect(pageData.productReferenceLabel).to.equal('invoice number')
+          expect(pageData.sessionReferenceNumber).to.equal('test invoice number')
+          expect(pageData.sessionAmount).to.equal(undefined)
+          expect(pageData.amountAsPence).to.equal(1000)
+          expect(pageData.amountAsGbp).to.equal('£10.00')
+          expect(pageData.canChangeAmount).to.equal(false)
+          expect(pageData.canChangeReference).to.equal(true)
+          expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
+        })
 
       it('when there is no reference in the session then it should redirect to the start page', () => {
         req = {
@@ -203,33 +302,36 @@ describe('Confirm Page Controller', () => {
 
       it('then it should update the page data so there is NO reference and display ' +
         'the confirm page', () => {
-        req = {
-          correlationId: '123',
-          product,
-          service
-        }
-        res = {
-          locals: {
-            __p: sinon.stub()
+          req = {
+            correlationId: '123',
+            product,
+            service
           }
-        }
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
+          }
 
-        mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns('1050')
+          mockPaymentLinkSession.getAmount.withArgs(req, product.externalId).returns('1050')
 
-        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
 
-        controller.getPage(req, res)
+          controller.getPage(req, res)
 
-        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
 
-        const pageData = mockResponses.response.args[0][3]
+          const pageData = mockResponses.response.args[0][3]
 
-        expect(pageData.productReferenceLabel).to.equal(undefined)
-        expect(pageData.sessionReferenceNumber).to.equal(undefined)
-        expect(pageData.sessionAmount).to.equal('1050')
-        expect(pageData.amountAsPence).to.equal('1050')
-        expect(pageData.amountAsGbp).to.equal('£10.50')
-      })
+          expect(pageData.productReferenceLabel).to.equal(undefined)
+          expect(pageData.sessionReferenceNumber).to.equal(undefined)
+          expect(pageData.sessionAmount).to.equal('1050')
+          expect(pageData.amountAsPence).to.equal('1050')
+          expect(pageData.amountAsGbp).to.equal('£10.50')
+          expect(pageData.canChangeAmount).to.equal(true)
+          expect(pageData.canChangeReference).to.equal(false)
+          expect(pageData.backLinkHref).to.equal('/pay/an-external-id/amount')
+        })
 
       it('when there is no amount in the session, then it should redirect to the start page', () => {
         req = {
@@ -251,6 +353,44 @@ describe('Confirm Page Controller', () => {
 
         sinon.assert.calledWith(res.redirect, '/pay/an-external-id')
       })
+    })
+
+    describe('when product.reference_enabled=false and product.price=1000', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: false,
+        price: 1000
+      }))
+
+      it('then it should display the confirm page with canChangeReference and canChangeAmount to ' +
+        'false and the back link set to the start page', () => {
+          req = {
+            correlationId: '123',
+            product,
+            service
+          }
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
+          }
+
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+
+          controller.getPage(req, res)
+
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+
+          const pageData = mockResponses.response.args[0][3]
+
+          expect(pageData.productReferenceLabel).to.equal(undefined)
+          expect(pageData.sessionReferenceNumber).to.equal(undefined)
+          expect(pageData.amountAsPence).to.equal(1000)
+          expect(pageData.amountAsGbp).to.equal('£10.00')
+          expect(pageData.canChangeAmount).to.equal(false)
+          expect(pageData.canChangeReference).to.equal(false)
+          expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
+        })
     })
 
     describe('when product.recaptcha=true', () => {
@@ -318,37 +458,37 @@ describe('Confirm Page Controller', () => {
         'ignore the hidden reference form field and ' +
         'use the amount from the hidden amount form field and ' +
         'redirect to the next_url ', async () => {
-        req = {
-          correlationId: '123',
-          product,
-          body: {
-            amount: '2000'
-          }
-        }
-
-        res = {
-          redirect: sinon.stub()
-        }
-
-        mockProductsClient.payment.create.resolves({
-          links: {
-            next: {
-              href: 'https://test.com'
+          req = {
+            correlationId: '123',
+            product,
+            body: {
+              amount: '2000'
             }
           }
+
+          res = {
+            redirect: sinon.stub()
+          }
+
+          mockProductsClient.payment.create.resolves({
+            links: {
+              next: {
+                href: 'https://test.com'
+              }
+            }
+          })
+
+          await controller.postPage(req, res)
+
+          sinon.assert.calledWith(
+            mockProductsClient.payment.create,
+            'an-external-id',
+            2000,
+            null
+          )
+          sinon.assert.calledWith(mockPaymentLinkSession.deletePaymentLinkSession, req, product.externalId)
+          sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
         })
-
-        await controller.postPage(req, res)
-
-        sinon.assert.calledWith(
-          mockProductsClient.payment.create,
-          'an-external-id',
-          2000,
-          null
-        )
-        sinon.assert.calledWith(mockPaymentLinkSession.deletePaymentLinkSession, req, product.externalId)
-        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
-      })
 
       it('when creating a payment causes an error, should call next() with an error', async () => {
         req = {
@@ -392,37 +532,37 @@ describe('Confirm Page Controller', () => {
         'using the `hidden reference form field` and ' +
         'use the amount from the `hidden amount form field` and ' +
         'redirect to the next_url ', async () => {
-        req = {
-          correlationId: '123',
-          product,
-          body: {
-            'reference-value': 'a-invoice-number',
-            amount: '2000'
-          }
-        }
-
-        res = {
-          redirect: sinon.stub()
-        }
-
-        mockProductsClient.payment.create.resolves({
-          links: {
-            next: {
-              href: 'https://test.com'
+          req = {
+            correlationId: '123',
+            product,
+            body: {
+              'reference-value': 'a-invoice-number',
+              amount: '2000'
             }
           }
+
+          res = {
+            redirect: sinon.stub()
+          }
+
+          mockProductsClient.payment.create.resolves({
+            links: {
+              next: {
+                href: 'https://test.com'
+              }
+            }
+          })
+
+          await controller.postPage(req, res)
+
+          sinon.assert.calledWith(
+            mockProductsClient.payment.create,
+            'an-external-id',
+            2000,
+            'a-invoice-number'
+          )
+          sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
         })
-
-        await controller.postPage(req, res)
-
-        sinon.assert.calledWith(
-          mockProductsClient.payment.create,
-          'an-external-id',
-          2000,
-          'a-invoice-number'
-        )
-        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
-      })
     })
 
     describe('when product.requireCaptcha=false, reference_enabled=false, product.price=1000, ', () => {
@@ -437,35 +577,35 @@ describe('Confirm Page Controller', () => {
         'use the product.price and ' +
         'ignore `hidden amount form field` and ' +
         'redirect to the next_url ', async () => {
-        req = {
-          correlationId: '123',
-          product,
-          body: {
-            amount: '2000'
-          }
-        }
-
-        res = {
-          redirect: sinon.stub()
-        }
-
-        mockProductsClient.payment.create.resolves({
-          links: {
-            next: {
-              href: 'https://test.com'
+          req = {
+            correlationId: '123',
+            product,
+            body: {
+              amount: '2000'
             }
           }
+
+          res = {
+            redirect: sinon.stub()
+          }
+
+          mockProductsClient.payment.create.resolves({
+            links: {
+              next: {
+                href: 'https://test.com'
+              }
+            }
+          })
+
+          await controller.postPage(req, res)
+
+          sinon.assert.calledWith(
+            mockProductsClient.payment.create,
+            'an-external-id',
+            1000
+          )
+          sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
         })
-
-        await controller.postPage(req, res)
-
-        sinon.assert.calledWith(
-          mockProductsClient.payment.create,
-          'an-external-id',
-          1000
-        )
-        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
-      })
     })
 
     describe('when product.requireCaptcha=false, reference_enabled=true, product.price=1000, ', () => {
@@ -480,37 +620,37 @@ describe('Confirm Page Controller', () => {
         'use the product.price and ' +
         'ignore `hidden amount form field` and ' +
         'redirect to the next_url', async () => {
-        req = {
-          correlationId: '123',
-          product,
-          body: {
-            'reference-value': 'a-invoice-number',
-            amount: '2000'
-          }
-        }
-
-        res = {
-          redirect: sinon.stub()
-        }
-
-        mockProductsClient.payment.create.resolves({
-          links: {
-            next: {
-              href: 'https://test.com'
+          req = {
+            correlationId: '123',
+            product,
+            body: {
+              'reference-value': 'a-invoice-number',
+              amount: '2000'
             }
           }
+
+          res = {
+            redirect: sinon.stub()
+          }
+
+          mockProductsClient.payment.create.resolves({
+            links: {
+              next: {
+                href: 'https://test.com'
+              }
+            }
+          })
+
+          await controller.postPage(req, res)
+
+          sinon.assert.calledWith(
+            mockProductsClient.payment.create,
+            'an-external-id',
+            1000,
+            'a-invoice-number'
+          )
+          sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
         })
-
-        await controller.postPage(req, res)
-
-        sinon.assert.calledWith(
-          mockProductsClient.payment.create,
-          'an-external-id',
-          1000,
-          'a-invoice-number'
-        )
-        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
-      })
     })
 
     describe('when product.requireCaptcha=true, reference_enabled=true, product.price=1000', () => {
@@ -524,125 +664,125 @@ describe('Confirm Page Controller', () => {
 
       it('when a successful captcha is entered, should redirect to the ' +
         'next_url', async () => {
-        req = {
-          correlationId: '123',
-          product,
-          body: {
-            'reference-value': 'a-invoice-number',
-            amount: '1000',
-            'g-recaptcha-response': 'recaptcha-test-token'
-          }
-        }
-
-        res = {
-          locals: {
-            __p: sinon.stub()
-          },
-          redirect: sinon.stub()
-        }
-
-        mockCaptcha.verifyCAPTCHAToken.withArgs('recaptcha-test-token').resolves(true)
-
-        mockProductsClient.payment.create.resolves({
-          links: {
-            next: {
-              href: 'https://test.com'
+          req = {
+            correlationId: '123',
+            product,
+            body: {
+              'reference-value': 'a-invoice-number',
+              amount: '1000',
+              'g-recaptcha-response': 'recaptcha-test-token'
             }
           }
+
+          res = {
+            locals: {
+              __p: sinon.stub()
+            },
+            redirect: sinon.stub()
+          }
+
+          mockCaptcha.verifyCAPTCHAToken.withArgs('recaptcha-test-token').resolves(true)
+
+          mockProductsClient.payment.create.resolves({
+            links: {
+              next: {
+                href: 'https://test.com'
+              }
+            }
+          })
+
+          await controller.postPage(req, res)
+
+          sinon.assert.calledWith(mockCaptcha.verifyCAPTCHAToken, 'recaptcha-test-token')
+
+          sinon.assert.calledWith(
+            mockProductsClient.payment.create,
+            'an-external-id',
+            1000,
+            'a-invoice-number'
+          )
+          sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
         })
-
-        await controller.postPage(req, res)
-
-        sinon.assert.calledWith(mockCaptcha.verifyCAPTCHAToken, 'recaptcha-test-token')
-
-        sinon.assert.calledWith(
-          mockProductsClient.payment.create,
-          'an-external-id',
-          1000,
-          'a-invoice-number'
-        )
-        sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
-      })
 
       it('when a failed captcha is entered, it should display an error and ' +
         'redirect to the confirm page and show the values from the hidden form fields to display ' +
         'the page so that it prevents session interference', async () => {
-        req = {
-          correlationId: '123',
-          product,
-          body: {
-            'reference-value': 'a-invoice-number',
-            amount: '2000',
-            'g-recaptcha-response': 'recaptcha-test-token'
+          req = {
+            correlationId: '123',
+            product,
+            body: {
+              'reference-value': 'a-invoice-number',
+              amount: '2000',
+              'g-recaptcha-response': 'recaptcha-test-token'
+            }
           }
-        }
 
-        res = {
-          locals: {
-            __p: sinon.stub()
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
           }
-        }
 
-        mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
+          mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('test invoice number')
 
-        mockCaptcha.verifyCAPTCHAToken.resolves(false)
+          mockCaptcha.verifyCAPTCHAToken.resolves(false)
 
-        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
-        res.locals.__p.withArgs('paymentLinksV2.fieldValidation.youMustSelectIAmNotARobot')
-          .returns('You failed the captcha challenge.  Please try again.')
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+          res.locals.__p.withArgs('paymentLinksV2.fieldValidation.youMustSelectIAmNotARobot')
+            .returns('You failed the captcha challenge.  Please try again.')
 
-        await controller.postPage(req, res)
+          await controller.postPage(req, res)
 
-        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
 
-        const pageData = mockResponses.response.args[0][3]
+          const pageData = mockResponses.response.args[0][3]
 
-        expect(pageData.productReferenceLabel).to.equal('invoice number')
-        expect(pageData.sessionReferenceNumber).to.equal('test invoice number')
-        expect(pageData.sessionAmount).to.equal(undefined)
-        expect(pageData.amountAsPence).to.equal(1000)
-        expect(pageData.amountAsGbp).to.equal('£10.00')
-        expect(pageData.requireCaptcha).to.equal(true)
+          expect(pageData.productReferenceLabel).to.equal('invoice number')
+          expect(pageData.sessionReferenceNumber).to.equal('test invoice number')
+          expect(pageData.sessionAmount).to.equal(undefined)
+          expect(pageData.amountAsPence).to.equal(1000)
+          expect(pageData.amountAsGbp).to.equal('£10.00')
+          expect(pageData.requireCaptcha).to.equal(true)
 
-        expect(pageData.errors).to.contain({
-          recaptcha: 'You failed the captcha challenge.  Please try again.'
+          expect(pageData.errors).to.contain({
+            recaptcha: 'You failed the captcha challenge.  Please try again.'
+          })
         })
-      })
 
       it('when the captcha call fails, it should display an error and ' +
         'redirect to the confirm page', async () => {
-        req = {
-          correlationId: '123',
-          product,
-          body: {
-            'reference-value': 'a-invoice-number',
-            amount: '1000',
-            'g-recaptcha-response': 'recaptcha-test-token'
+          req = {
+            correlationId: '123',
+            product,
+            body: {
+              'reference-value': 'a-invoice-number',
+              amount: '1000',
+              'g-recaptcha-response': 'recaptcha-test-token'
+            }
           }
-        }
 
-        res = {
-          locals: {
-            __p: sinon.stub()
+          res = {
+            locals: {
+              __p: sinon.stub()
+            }
           }
-        }
 
-        mockCaptcha.verifyCAPTCHAToken.rejects()
+          mockCaptcha.verifyCAPTCHAToken.rejects()
 
-        res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
-        res.locals.__p.withArgs('paymentLinksV2.fieldValidation.youMustSelectIAmNotARobot')
-          .returns('There was an issue with the recaptcha.  Please try again.')
+          res.locals.__p.withArgs('paymentLinksV2.confirm.totalToPay').returns('Total to pay')
+          res.locals.__p.withArgs('paymentLinksV2.fieldValidation.youMustSelectIAmNotARobot')
+            .returns('There was an issue with the recaptcha.  Please try again.')
 
-        await controller.postPage(req, res)
+          await controller.postPage(req, res)
 
-        sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
+          sinon.assert.calledWith(responseSpy, req, res, 'confirm/confirm')
 
-        const pageData = mockResponses.response.args[0][3]
+          const pageData = mockResponses.response.args[0][3]
 
-        expect(pageData.errors).to.contain({
-          recaptcha: 'There was an issue with the recaptcha.  Please try again.'
+          expect(pageData.errors).to.contain({
+            recaptcha: 'There was an issue with the recaptcha.  Please try again.'
+          })
         })
-      })
     })
   })
 })

--- a/app/payment-link-v2/confirm/confirm.njk
+++ b/app/payment-link-v2/confirm/confirm.njk
@@ -1,5 +1,6 @@
 {% extends "../../views/layout.njk" %}
 
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../views/macros/error-summary.njk" import errorSummary %}
 
@@ -7,9 +8,20 @@
   Confirm  - {{ productName }}
 {% endblock %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref,
+    attributes: {
+      'data-cy': 'back-link'
+    }
+  }) }}
+{% endblock %}
+
 {% block contentBody %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
       {{ errorSummary ({
         errors: errors
       }) }}

--- a/app/payment-link-v2/reference/reference.njk
+++ b/app/payment-link-v2/reference/reference.njk
@@ -8,17 +8,19 @@
   {{ __p('paymentLinksV2.reference.pleaseEnterYour') }} {{product.reference_label}}  - {{ productName }}
 {% endblock %}
 
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkHref,
+    attributes: {
+      'data-cy': 'back-link'
+    }
+  }) }}
+{% endblock %}
+
 {% block contentBody %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    {{ govukBackLink({
-      text: "Back",
-      href: backLinkHref,
-      attributes: {
-        'data-cy': 'back-link'
-      }
-    }) }}
-
     {{ errorSummary ({
       errors: errors,
       hrefs: {

--- a/test/cypress/integration/payment-link-v2/confirm.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/confirm.cy.test.js
@@ -71,6 +71,7 @@ describe('Confirm page', () => {
         cy.visit('/pay/a-product-id/confirm')
 
         cy.get('[data-cy=product-name]').should('contain', 'A Product Name')
+        cy.get('[data-cy=back-link]').should('have.attr', 'href', '/pay/a-product-id')
 
         checkNumberOfRows(1)
         checkAmountRow(0)
@@ -205,6 +206,7 @@ describe('Confirm page', () => {
         cy.url().should('include', '/pay/a-product-id/confirm')
 
         cy.get('[data-cy=product-name]').should('contain', 'A Product Name')
+        cy.get('[data-cy=back-link]').should('have.attr', 'href', '/pay/a-product-id/amount')
 
         checkNumberOfRows(1)
         checkAmountRow(0, true)
@@ -258,6 +260,7 @@ describe('Confirm page', () => {
         cy.url().should('include', '/pay/a-product-id/confirm')
 
         cy.get('[data-cy=product-name]').should('contain', 'A Product Name')
+        cy.get('[data-cy=back-link]').should('have.attr', 'href', '/pay/a-product-id/amount')
 
         checkNumberOfRows(2)
         checkReferenceRow(0, true)

--- a/test/fixtures/product.fixtures.js
+++ b/test/fixtures/product.fixtures.js
@@ -42,7 +42,7 @@ module.exports = {
     if (data.type !== 'ADHOC') {
       data.price = data.price || 1000
     }
-    if (opts.reference_enabled) data.reference_enabled = opts.reference_enabled
+    if (opts.reference_enabled !== undefined) data.reference_enabled = opts.reference_enabled
     if (opts.reference_label) data.reference_label = opts.reference_label
     if (opts.reference_hint) data.reference_hint = opts.reference_hint
     if (opts.description) data.description = opts.description


### PR DESCRIPTION
## Review note

Disable whitespace changes to make reviewing easier, as indentation changed in the test file

## What

Add a back link on the confirm page which links to the previous page in
the journey.

Also fix the styling of the back link so that it appears just below the
header banner on all pages, as per the design system guidance.

This previous page is:

The amount page, if the amount is user provided and wasn't provided by
the service in query parameters

ELSE

The reference page, if the reference is user provided and wasn't
provided by the service in query parameters

ELSE

The payment links start page.

<img width="1182" alt="Screenshot 2022-04-22 at 12 25 06" src="https://user-images.githubusercontent.com/5648592/164705586-70452fad-9883-4e13-b151-30d2bd9b71e9.png">