### PR TITLE
PP-9477 Reference confirm page

### DIFF
--- a/app/payment-link-v2/amount/amount.njk
+++ b/app/payment-link-v2/amount/amount.njk
@@ -10,7 +10,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    text: "Back",
+    text: __p('paymentLinksV2.common.back'),
     href: backLinkHref,
     attributes: {
       'data-cy': 'back-link'

--- a/app/payment-link-v2/confirm/confirm.njk
+++ b/app/payment-link-v2/confirm/confirm.njk
@@ -10,7 +10,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    text: "Back",
+    text: __p('paymentLinksV2.common.back'),
     href: backLinkHref,
     attributes: {
       'data-cy': 'back-link'

--- a/app/payment-link-v2/reference-confirm/reference-confirm.controller.js
+++ b/app/payment-link-v2/reference-confirm/reference-confirm.controller.js
@@ -1,10 +1,34 @@
 'use strict'
 
+const lodash = require('lodash')
+
 const { response } = require('../../utils/response')
 const { NotFoundError } = require('../../errors')
-const { paymentLinksV2 } = require('../../paths')
+const paths = require('../../paths')
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
 const paymentLinkSession = require('../utils/payment-link-session')
+
+const CONFIRM_REFERENCE = 'confirm-reference'
+
+function getNextPageUrl (productPrice, isEditing, confirmReference, amountProvidedByQueryParams) {
+  if (confirmReference === 'no') {
+    return paths.paymentLinksV2.reference
+  } else if (productPrice || isEditing || amountProvidedByQueryParams) {
+    return paths.paymentLinksV2.confirm
+  } else {
+    return paths.paymentLinksV2.amount
+  }
+}
+
+function validateConfirmReferenceFormValue (confirmReference, res) {
+  const errors = {}
+
+  if (!confirmReference) {
+    errors[CONFIRM_REFERENCE] = res.locals.__p('paymentLinksV2.referenceConfirm.youMustChooseAnOption')
+  }
+
+  return errors
+}
 
 function getPage (req, res, next) {
   const product = req.product
@@ -21,10 +45,32 @@ function getPage (req, res, next) {
     paymentReferenceHint: product.reference_hint
   }
 
-  data.referencePageUrl = replaceParamsInPath(paymentLinksV2.reference, product.externalId)
+  const sessionReferenceNumber = paymentLinkSession.getReference(req, product.externalId)
 
-  const confirmAndContinueUrlPath = product.price ? paymentLinksV2.confirm : paymentLinksV2.amount
-  data.confirmAndContinuePageUrl = replaceParamsInPath(confirmAndContinueUrlPath, product.externalId)
+  if (sessionReferenceNumber) {
+    data.reference = sessionReferenceNumber
+  }
+
+  const backLinkHref = replaceParamsInPath(paths.paymentLinksV2.reference, product.externalId)
+  data.backLinkHref = backLinkHref
+
+  return response(req, res, 'reference-confirm/reference-confirm', data)
+}
+
+function postPage (req, res, next) {
+  const confirmReference = lodash.get(req.body, CONFIRM_REFERENCE, '')
+  const product = req.product
+  const { change } = req.query || {}
+
+  const errors = validateConfirmReferenceFormValue(confirmReference, res)
+
+  const backLinkHref = replaceParamsInPath(paths.paymentLinksV2.reference, product.externalId)
+
+  const data = {
+    productExternalId: product.externalId,
+    productName: product.name,
+    backLinkHref: backLinkHref
+  }
 
   const sessionReferenceNumber = paymentLinkSession.getReference(req, product.externalId)
 
@@ -32,9 +78,19 @@ function getPage (req, res, next) {
     data.reference = sessionReferenceNumber
   }
 
-  return response(req, res, 'reference-confirm/reference-confirm', data)
+  if (!lodash.isEmpty(errors)) {
+    data.errors = errors
+
+    return response(req, res, 'reference-confirm/reference-confirm', data)
+  }
+
+  const amountProvidedByQueryParams = paymentLinkSession.getAmountProvidedByQueryParams(req, product.externalId)
+
+  const redirectUrl = getNextPageUrl(product.price, change, confirmReference, amountProvidedByQueryParams)
+  return res.redirect(replaceParamsInPath(redirectUrl, product.externalId))
 }
 
 module.exports = {
-  getPage
+  getPage,
+  postPage
 }

--- a/app/payment-link-v2/reference-confirm/reference-confirm.controller.test.js
+++ b/app/payment-link-v2/reference-confirm/reference-confirm.controller.test.js
@@ -44,20 +44,15 @@ describe('Reference Confirm Page Controller', () => {
       }))
 
       it('when the reference is in the session, then it should display the REFERENCE CONFIRM page ' +
-        'and set the `back` link to the REFERENCE page ' +
-        'and set the  `confirm and continue` link to the AMOUNT page', () => {
+        'and set the `back` link to the REFERENCE page', () => {
         req = {
           correlationId: '123',
           product,
           service
         }
 
-        res = {
-          redirect: sinon.spy(),
-          locals: {
-            __p: sinon.stub()
-          }
-        }
+        res = {}
+
         mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('reference test value')
         controller.getPage(req, res)
 
@@ -65,8 +60,6 @@ describe('Reference Confirm Page Controller', () => {
 
         const pageData = mockResponses.response.args[0][3]
         expect(pageData.reference).to.equal('reference test value')
-        expect(pageData.referencePageUrl).to.equal('/pay/an-external-id/reference')
-        expect(pageData.confirmAndContinuePageUrl).to.equal('/pay/an-external-id/amount')
       })
     })
 
@@ -79,20 +72,15 @@ describe('Reference Confirm Page Controller', () => {
       }))
 
       it('when the reference is in the session, then it should display the REFERENCE CONFIRM page ' +
-        'and set the `back` link to the REFERENCE page' +
-        'and set the  `confirm and continue` link to the CONFIRM page', () => {
+        'and set the `back` link to the REFERENCE page', () => {
         req = {
           correlationId: '123',
           product,
           service
         }
 
-        res = {
-          redirect: sinon.spy(),
-          locals: {
-            __p: sinon.stub()
-          }
-        }
+        res = {}
+
         mockPaymentLinkSession.getReference.withArgs(req, product.externalId).returns('reference test value')
         controller.getPage(req, res)
 
@@ -100,8 +88,6 @@ describe('Reference Confirm Page Controller', () => {
 
         const pageData = mockResponses.response.args[0][3]
         expect(pageData.reference).to.equal('reference test value')
-        expect(pageData.referencePageUrl).to.equal('/pay/an-external-id/reference')
-        expect(pageData.confirmAndContinuePageUrl).to.equal('/pay/an-external-id/confirm')
       })
     })
 
@@ -119,6 +105,7 @@ describe('Reference Confirm Page Controller', () => {
           service
         }
         res = {}
+
         const next = sinon.spy()
         controller.getPage(req, res, next)
 
@@ -126,6 +113,170 @@ describe('Reference Confirm Page Controller', () => {
           .and(sinon.match.has('message', 'Attempted to access reference confirm page with a product that auto-generates references.'))
 
         sinon.assert.calledWith(next, expectedError)
+      })
+    })
+  })
+
+  describe('postPage', () => {
+    describe('when the product has no price', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'invoice number',
+        price: null
+      }))
+
+      it('when the user confirms the reference then it should redirect to the amount page', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'confirm-reference': 'yes'
+          }
+        }
+
+        res = {
+          redirect: sinon.spy()
+        }
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(res.redirect, '/pay/an-external-id/amount')
+      })
+
+      it('when the user does NOT confirm the reference then it should redirect to the reference page', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'confirm-reference': 'no'
+          }
+        }
+
+        res = {
+          redirect: sinon.spy()
+        }
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference')
+      })
+
+      it('when the user does NOT selet an option then it should show an error', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'confirm-reference': undefined
+          }
+        }
+
+        res = {
+          locals: {
+            __p: sinon.stub()
+          }
+        }
+
+        res.locals.__p.withArgs('paymentLinksV2.referenceConfirm.youMustChooseAnOption').returns('You must select an option')
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(responseSpy, req, res, 'reference-confirm/reference-confirm')
+
+        const pageData = mockResponses.response.args[0][3]
+        expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
+
+        expect(pageData.errors['confirm-reference']).to.equal('You must select an option')
+      })
+
+      it('when change query parameter is present and user select `yes`, it should redirect to the confirm page', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'confirm-reference': 'yes'
+          },
+          query: {
+            change: 'true'
+          }
+        }
+
+        res = {
+          redirect: sinon.spy()
+        }
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
+      })
+
+      it('when amount was provided by query parameters and the user selects `yes`, should redirect to the confirm page', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'confirm-reference': 'yes'
+          },
+          session: {}
+        }
+
+        req.session[product.externalId] = {
+          amount: 1000,
+          amountProvidedByQueryParams: true
+        }
+
+        res = {
+          redirect: sinon.spy()
+        }
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
+      })
+    })
+
+    describe('when the product has a price', () => {
+      const product = new Product(productFixtures.validProductResponse({
+        type: 'ADHOC',
+        reference_enabled: true,
+        reference_label: 'invoice number',
+        price: 1000
+      }))
+
+      it('when the user confirms the reference then it should redirect to the confirm page', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'confirm-reference': 'yes'
+          }
+        }
+
+        res = {
+          redirect: sinon.spy()
+        }
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
+      })
+
+      it('when the user does NOT confirm the reference then it should redirect to the reference page', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'confirm-reference': 'no'
+          }
+        }
+
+        res = {
+          redirect: sinon.spy()
+        }
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference')
       })
     })
   })

--- a/app/payment-link-v2/reference-confirm/reference-confirm.njk
+++ b/app/payment-link-v2/reference-confirm/reference-confirm.njk
@@ -2,51 +2,84 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "../../views/macros/error-summary.njk" import errorSummary %}
 
 {% block pageTitle %}
-  {{ __p('paymentLinksV2.referenceConfirm.areYouSureThisIsAReferenceNumber') }}  - {{ productName }}
+  {{ __p('paymentLinksV2.referenceConfirm.confirmYourReferenceNumber') }}  - {{ productName }}
+{% endblock %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: __p('paymentLinksV2.common.back'),
+    href: backLinkHref,
+    attributes: {
+      'data-cy': 'back-link'
+    }
+  }) }}
 {% endblock %}
 
 {% block contentBody %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-l" data-cy="product-name">{{ productName }}</h1>  
+    {% set hintHtml %}
+      <p class="govuk-body">{{ __p('paymentLinksV2.referenceConfirm.checkYouveEnteredTheNumberCorrectly') }}</p>
 
-    {% if productDescription %}
-      <p class="govuk-body" data-cy="description">{{ productDescription }}</p>
-    {% endif %}
+      {{ govukInsetText({
+        text: reference,
+        classes: "govuk-!-font-weight-bold",
+        attributes: { 'data-cy': 'reference' }
+      }) }} 
+    {% endset %}
 
-    <h2 class="govuk-heading-m" data-cy="reference-label">{{ paymentReferenceLabel | capitalize }}</h2>
-
-    {% if paymentReferenceHint %}
-      <p class="govuk-hint" data-cy="reference-hint">{{ paymentReferenceHint }}</p>    
-    {% endif %}
-
-    {{ govukInsetText({
-      text: reference,
-      classes: "govuk-!-font-weight-bold",
-      attributes: { 'data-cy': 'reference' }
+    {{ errorSummary ({
+      errors: errors,
+      hrefs: {
+        'confirm-reference': '#confirm-reference'
+      }
     }) }}
 
+    {% set radioErrorMessage = { text: errors['confirm-reference'], attributes: { 'data-cy': 'error-message'} } if errors['confirm-reference'] %}  
 
-    <h2 class="govuk-heading-m">{{ __p('paymentLinksV2.referenceConfirm.areYouSureThisIsAReferenceNumber') }}</h2>
+    <form method="post">
+      <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
-    <p class="govuk-body">{{ __p('paymentLinksV2.referenceConfirm.checkYouveEnteredTheNumberCorrectly') }}</p>
+      {{ govukRadios({
+        idPrefix: "confirm-reference",
+        name: "confirm-reference",
+        fieldset: {
+        legend: {
+          isPageHeading: true,
+          text: __p('paymentLinksV2.referenceConfirm.confirmYourReferenceNumber'),
+          classes: "govuk-fieldset__legend--l"
+          }
+        },
+        hint: {
+          html: hintHtml
+        },
+        items: [
+          {
+            value: "yes",
+            text: __p('paymentLinksV2.referenceConfirm.yesThisIsTheCorrectReferenceNumber'),
+            attributes: {'data-cy': 'yes-radio'}
+          },
+          {
+            value: "no",
+            text: __p('paymentLinksV2.referenceConfirm.noItIsIncorrect'),
+            attributes: {'data-cy': 'no-radio'}
+          }
+        ],
+        errorMessage: radioErrorMessage
+        })
+      }}
 
-    <div class="govuk-button-group">
       {{ govukButton({
-        text: __p('paymentLinksV2.referenceConfirm.confirmAndContinue'),
-        href: confirmAndContinuePageUrl,
-        attributes: { 'data-cy': 'confirm-button' }
-      }) }}
-
-      {{ govukButton({
-        text: __p('paymentLinksV2.referenceConfirm.edit'),
-        href: referencePageUrl,
-        classes: 'govuk-button--secondary',
-        attributes: { 'data-cy': 'edit-button' }
-      }) }}
-    </div>
+        text: __p('buttons.continue'),
+        attributes: {
+          'data-cy': 'button'
+        }
+      }) }} 
+    </form>
   </div>  
 </div>
 {% endblock %}

--- a/app/payment-link-v2/reference/reference.controller.js
+++ b/app/payment-link-v2/reference/reference.controller.js
@@ -30,7 +30,7 @@ function validateReferenceFormValue (reference, referenceLabel, res) {
 
 function getNextPageUrl (productPrice, isEditing, reference, amountProvidedByQueryParams) {
   if (isAPotentialPan(reference)) {
-    return paths.paymentLinksV2.referenceConfirm
+    return paths.paymentLinksV2.referenceConfirm + (isEditing ? '?change=true' : '')
   } else if (productPrice || isEditing || amountProvidedByQueryParams) {
     return paths.paymentLinksV2.confirm
   } else {

--- a/app/payment-link-v2/reference/reference.controller.test.js
+++ b/app/payment-link-v2/reference/reference.controller.test.js
@@ -227,6 +227,29 @@ describe('Reference Page Controller', () => {
         sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference/confirm')
       })
 
+      it('when reference is a potential card number and there is the `change` query parameter, it should  ' +
+      'redirect to the REFERENCE CONFIRM page with the `change` query parameter', () => {
+        req = {
+          correlationId: '123',
+          product,
+          body: {
+            'payment-reference': '4242424242424242'
+          },
+          query: {
+            change: 'true'
+          }
+        }
+
+        res = {
+          redirect: sinon.spy()
+        }
+
+        controller.postPage(req, res)
+
+        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, '4242424242424242')
+        sinon.assert.calledWith(res.redirect, '/pay/an-external-id/reference/confirm?change=true')
+      })
+
       it('when an empty reference is entered, it should display an error message with the `reference_label` and the back link correctly', () => {
         req = {
           correlationId: '123',

--- a/app/payment-link-v2/reference/reference.njk
+++ b/app/payment-link-v2/reference/reference.njk
@@ -10,7 +10,7 @@
 
 {% block beforeContent %}
   {{ govukBackLink({
-    text: "Back",
+    text: __p('paymentLinksV2.common.back'),
     href: backLinkHref,
     attributes: {
       'data-cy': 'back-link'

--- a/app/routes.js
+++ b/app/routes.js
@@ -71,6 +71,7 @@ module.exports.bind = function (app) {
   app.post(paymentLinksV2.reference, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, referenceCtrl.postPage)
 
   app.get(paymentLinksV2.referenceConfirm, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, referenceConfirmCtrl.getPage)
+  app.post(paymentLinksV2.referenceConfirm, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, referenceConfirmCtrl.postPage)
 
   app.get(paymentLinksV2.amount, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, amountCtrl.getPage)
   app.post(paymentLinksV2.amount, ensureSessionHasCsrfSecret, validateAndRefreshCsrf, resolveProduct, resolveLanguage, amountCtrl.postPage)

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -59,6 +59,9 @@
     "potentialPANInReference": "Gwiriwch eich bod wedi nodi’r rhif yn gywir cyn gwneud y taliad. Peidiwch â nodi’ch rhif cerdyn debyd neu gredyd."
   },
   "paymentLinksV2": {
+    "common": {
+      "back": "TODO convert to Welsh - Back"
+    },
     "start": {
       "title": "TODO convert to Welsh - Make a payment"
     },
@@ -66,10 +69,12 @@
       "pleaseEnterYour": "TODO convert to Welsh - Enter your"
     },
     "referenceConfirm": {
-      "areYouSureThisIsAReferenceNumber": "TODO convert to Welsh - Are you sure this is a reference number?",
-      "checkYouveEnteredTheNumberCorrectly": "TODO convert to Welsh - Check that you've entered the number correctly before making the payment. Do not enter your debit or credit card number.",
-      "confirmAndContinue": "TODO convert to Welsh - Confirm and continue",
-      "edit": "TODO convert to Welsh - Edit"
+      "confirmYourReferenceNumber": "TODO convert to Welsh - Confirm your reference number",
+			"checkYouveEnteredTheNumberCorrectly": "TODO convert to Welsh - Check that you've entered the number correctly before making the payment. Do not enter your debit or credit card number.",
+			"yesThisIsTheCorrectReferenceNumber": "TODO convert to Welsh - Yes, this is the correct reference number",
+			"noItIsIncorrect": "TODO convert to Welsh - No, it is not correct",
+			"continue": "TODO convert to Welsh - Continue",
+			"youMustChooseAnOption": "TODO convert to Welsh - You must choose an option"
     },
     "amount": {
       "enterAmountToPay": "TODO convert to Welsh - Enter amount to pay"

--- a/locales/en.json
+++ b/locales/en.json
@@ -59,27 +59,32 @@
     "potentialPANInReference": "Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number."
   },
   "paymentLinksV2": {
+    "common": {
+      "back": "Back"
+    },
     "start": {
       "title": "Make a payment"
     },
     "reference": {
-			"pleaseEnterYour": "Enter your"
-		},
-		"referenceConfirm": {
-			"areYouSureThisIsAReferenceNumber": "Are you sure this is a reference number?",
-			"checkYouveEnteredTheNumberCorrectly": "Check that you've entered the number correctly before making the payment. Do not enter your debit or credit card number.",
-			"confirmAndContinue": "Confirm and continue",
-			"edit": "Edit"
-		},
+      "pleaseEnterYour": "Enter your"
+    },
+    "referenceConfirm": {
+      "confirmYourReferenceNumber": "Confirm your reference number",
+      "checkYouveEnteredTheNumberCorrectly": "Check that you've entered the number correctly before making the payment. Do not enter your debit or credit card number.",
+      "yesThisIsTheCorrectReferenceNumber": "Yes, this is the correct reference number",
+      "noItIsIncorrect": "No, it is not correct",
+      "continue": "Continue",
+      "youMustChooseAnOption": "You must choose an option"
+    },
     "amount": {
-			"enterAmountToPay": "Enter amount to pay"
-		},
+      "enterAmountToPay": "Enter amount to pay"
+    },
     "confirm": {
-			"checkYourDetails": "Check your details",
+      "checkYourDetails": "Check your details",
       "totalToPay": "Total to pay",
       "change": "Change",
       "continueToPayment": "Continue to payment"
-		},
+    },
     "fieldValidation": {
       "enterAnAmountInPounds": "Enter an amount of money to pay",
       "enterAnAmountInTheCorrectFormat": "Enter an amount in pounds and pence using digits and a decimal point, like 123.45 or 156.00",

--- a/test/cypress/integration/payment-link-v2/reference-and-reference-confirm.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/reference-and-reference-confirm.cy.test.js
@@ -50,35 +50,39 @@ describe('Reference and reference confirm page', () => {
       })
 
       it('when an reference is entered that looks like a card number, should go to the `reference confirm` page', () => {
+        Cypress.Cookies.preserveOnce('session')
         cy.get('[data-cy=input]')
           .clear()
           .type('4444333322221111', { delay: 0 })
         cy.get('[data-cy=button]').click()
 
-        cy.title().should('contain', 'Are you sure this is a reference number?')
+        cy.title().should('contain', 'Confirm your reference number - A Product Name')
       })
     })
 
     describe('Reference confirm page', () => {
       it('should display the `reference confirm` page correctly', () => {
         Cypress.Cookies.preserveOnce('session')
-        cy.get('[data-cy=product-name]').should('contain', 'A Product Name')
-        cy.get('[data-cy=description]').should('contain', 'Product description')
-        cy.get('[data-cy=reference-label]').should('contain', 'Invoice number')
-        cy.get('[data-cy=reference-hint]').should('contain', 'Invoice number hint')
+        cy.get('[data-cy=back-link]').should('have.attr', 'href', '/pay/a-product-id/reference')
         cy.get('[data-cy=reference]').should('contain', '4444333322221111')
-
-        cy.get('[data-cy=confirm-button]')
-          .should('contain', 'Confirm and continue')
-          .should('have.attr', 'href', '/pay/a-product-id/amount')
-
-        cy.get('[data-cy=edit-button]')
-          .should('contain', 'Edit')
-          .should('have.attr', 'href', '/pay/a-product-id/reference')
+        cy.get('[data-cy=button]').should('exist')
       })
 
-      it('when `click and confirm` is clicked, should then go to the amount page', () => {
-        cy.get('[data-cy=confirm-button]').click()
+      it('when no radio option is selected and the `Continue` button is clicked, should display an error', () => {
+        Cypress.Cookies.preserveOnce('session')
+        cy.get('[data-cy=button]').click()
+
+        cy.get('[data-cy=error-summary] a')
+          .should('contain', 'You must choose an option')
+          .should('have.attr', 'href', '#confirm-reference')
+
+        cy.get('[data-cy=error-message]').should('contain', 'You must choose an option')
+      })
+
+      it('when `Yes` is selected and `Continue` is clicked, should then go to the amount page', () => {
+        Cypress.Cookies.preserveOnce('session')
+        cy.get('[data-cy=yes-radio]').click()
+        cy.get('[data-cy=button]').click()
 
         cy.title().should('contain', 'Enter amount to pay - A Product Name')
       })


### PR DESCRIPTION
- Update page to use new design
  - Update nunjuks file to use radio buttons
  - Controller
    - Update to use radio buttons
    - Add validation for radio buttons
    - Forward to the right page when a valid option has been selected
      - Skip the amount page when editng reference, fixed price, price in query params.
- Add unit tests.
- Update Cypress tests.