### PR TITLE
PP-9614 Fix bug where we can respond twice to a request

### DIFF
--- a/app/controllers/adhoc-payment/post-index.controller.js
+++ b/app/controllers/adhoc-payment/post-index.controller.js
@@ -21,7 +21,7 @@ module.exports = async (req, res) => {
       req.referenceNumber = sessionReferenceNumber
       setSessionVariable(req, 'referenceNumber', '')
     } else {
-      productReferenceCtrl.index(req, res)
+      return productReferenceCtrl.index(req, res)
     }
   }
 


### PR DESCRIPTION
In app/controllers/adhoc-payment/post-index.controller.js we were not returning after calling another controller which renders a page. This meant that we could attempt to call the controller to to make a payment after rendering the reference page, which would cause an error to be thrown and then attempt to render an error page after the request had already been responded to.

I wasn't able to reproduce the circumstances this happens under, but it has been witnessed on production.