### PR TITLE
BAU: Readme typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pay-products-ui 
 
-User interface app for product payments (Prototype/Demo/Ad-hoc ..etc) integrated with GOVUK Pay.
+User interface app for product payments (Prototype/Demo/Ad-hoc etc) integrated with GOVUK Pay.
 
 ## Running locally
 


### PR DESCRIPTION
This change is to test the post-merge pact workflow, now that we are excluding some (Github Actions related) commits from the provider post-merge pact tests (see https://github.com/alphagov/pay-products/pull/931). 