### PR TITLE
PP-9587 Show specific error message when account cannot take payments

### DIFF
--- a/app/controllers/make-payment.controller.js
+++ b/app/controllers/make-payment.controller.js
@@ -7,6 +7,7 @@ const productsClient = require('../services/clients/products.client')
 
 // Constants
 const errorMessagePath = 'error.internal' // This is the object notation to string in en.json
+const paymentForbiddenErrorMessagePath = 'error.accountCannotTakePayments'
 
 module.exports = (req, res) => {
   const product = req.product
@@ -22,7 +23,11 @@ module.exports = (req, res) => {
       })
       .catch(err => {
         logger.info(`[${correlationId}] error creating charge for product ${product.externalId}. err = ${err}`)
-        return renderErrorView(req, res, errorMessagePath, err.errorCode || 500)
+        if (err.errorCode === 403) {
+          return renderErrorView(req, res, paymentForbiddenErrorMessagePath, 400)
+        } else {
+          return renderErrorView(req, res, errorMessagePath, err.errorCode || 500)
+        }
       })
   } else {
     logger.error(`[${correlationId}] product not found to make payment`)

--- a/app/errors.js
+++ b/app/errors.js
@@ -11,6 +11,10 @@ class DomainError extends Error {
 class NotFoundError extends DomainError {
 }
 
+class AccountCannotTakePaymentsError extends DomainError {
+}
+
 module.exports = {
-  NotFoundError
+  NotFoundError,
+  AccountCannotTakePaymentsError
 }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -1,9 +1,10 @@
 'use strict'
 
-const { NotFoundError } = require('../errors')
+const { NotFoundError, AccountCannotTakePaymentsError } = require('../errors')
 const { response } = require('../utils/response')
 
 const logger = require('../utils/logger')(__filename)
+const accountCannotTakePaymentsErrorMessagePath = 'error.accountCannotTakePayments'
 
 module.exports = function (err, req, res, next) {
   const errorPayload = {
@@ -32,6 +33,11 @@ module.exports = function (err, req, res, next) {
     logger.info(`[${req.correlationId}] NotFoundError handled: ${err.message}. Rendering 404 page`)
     res.status(404)
     return response(req, res, '404')
+  }
+  if (err instanceof AccountCannotTakePaymentsError) {
+    logger.info(`[${req.correlationId}] AccountCannotTakePaymentsError handled: ${err.message}. Rendering error page`)
+    res.status(400)
+    return response(req, res, 'error', { message: accountCannotTakePaymentsErrorMessagePath })
   }
 
   logger.error(`[requestId=${req.correlationId}] Internal server error`, errorPayload)

--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -8,6 +8,7 @@ const captcha = require('../../utils/captcha')
 const logger = require('../../utils/logger')(__filename)
 const productsClient = require('../../services/clients/products.client')
 const paymentLinkSession = require('../utils/payment-link-session')
+const { AccountCannotTakePaymentsError } = require('../../errors')
 
 const HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE = 'reference-value'
 const HIDDEN_FORM_FIELD_ID_AMOUNT = 'amount'
@@ -132,6 +133,9 @@ async function postPage (req, res, next) {
     paymentLinkSession.deletePaymentLinkSession(req, product.externalId)
     res.redirect(303, payment.links.next.href)
   } catch (error) {
+    if (error.errorCode === 403) {
+      return next(new AccountCannotTakePaymentsError('Forbidden response returned by Public API when creating payment'))
+    }
     return next(error)
   }
 }

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -17,7 +17,8 @@
   "error": {
     "title": "Digwyddodd gwall:",
     "default": "Mae’n ddrwg gennym, ond ni allwn brosesu eich cais. Rhowch gynnig arall arni wedyn.",
-    "internal": "Mae problem gyda’r cyfleuster taliadau. Rhowch gynnig arall arni wedyn"
+    "internal": "Mae problem gyda’r cyfleuster taliadau. Rhowch gynnig arall arni wedyn",
+    "accountCannotTakePayments": "Mae problem gyda’r cyfleuster taliadau. Rhowch gynnig arall arni wedyn"
   },
   "404Page": {
     "title": "TODO convert to Welsh - Page not found",

--- a/locales/en.json
+++ b/locales/en.json
@@ -17,7 +17,8 @@
   "error": {
     "title": "An error occurred:",
     "default": "There’s a problem with the payments platform. Please try again later",
-    "internal": "Sorry, we’re unable to process your request. Try again later."
+    "internal": "Sorry, we’re unable to process your request. Try again later.",
+    "accountCannotTakePayments": "Please contact the service you are trying to make a payment to."
   },
   "404Page": {
     "title": "Page not found",


### PR DESCRIPTION
When an account is unable to take payments, a 403 error is returned
from Products when making a POST request to create a payment.

The 403 indicates that either:
- The account has been disabled
- The account does not have the PSP configuration added

Show a specific error message if creating a payment fails due to this.

Make this change in both `make-payment.controller.js` which is used by
the current payment link journey to create the payment and in 
`confirm.controller.js` which is used by the future payment link journey