### PR TITLE
PP-9780 Stop deleting cookies when redirecting to payment page

### DIFF
--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -130,7 +130,6 @@ async function postPage (req, res, next) {
       referenceToUseForPayment
     )
 
-    paymentLinkSession.deletePaymentLinkSession(req, product.externalId)
     res.redirect(303, payment.links.next.href)
   } catch (error) {
     if (error.errorCode === 403) {

--- a/app/payment-link-v2/confirm/confirm.controller.test.js
+++ b/app/payment-link-v2/confirm/confirm.controller.test.js
@@ -487,7 +487,6 @@ describe('Confirm Page Controller', () => {
           2000,
           null
         )
-        sinon.assert.calledWith(mockPaymentLinkSession.deletePaymentLinkSession, req, product.externalId)
         sinon.assert.calledWith(res.redirect, 303, 'https://test.com')
       })
 


### PR DESCRIPTION
- Removed  method deleting cookies when redirecting to the payment page
- Updated unit test to match removing cookies that delete the session when redirecting to payment page