### PR TITLE
PP-10028 Fix IEEE 754 floating-point arithmetic errors

### DIFF
--- a/app/payment-link-v2/amount/amount.controller.js
+++ b/app/payment-link-v2/amount/amount.controller.js
@@ -9,6 +9,7 @@ const paths = require('../../paths')
 const { validateAmount } = require('../../utils/validation/form-validations')
 const replaceParamsInPath = require('../../utils/replace-params-in-path')
 const paymentLinkSession = require('../utils/payment-link-session')
+const { convertPoundsAndPenceToPence, convertPenceToPoundsAndPence } = require('../../utils/currency')
 
 const PAYMENT_AMOUNT = 'payment-amount'
 
@@ -40,7 +41,7 @@ function getPage (req, res, next) {
   data.backLinkHref = getBackLinkUrl(change, product, referenceProvidedByQueryParams)
 
   if (sessionAmount) {
-    data.amount = (parseFloat(sessionAmount) / 100).toFixed(2)
+    data.amount = convertPenceToPoundsAndPence(sessionAmount)
   }
 
   return response(req, res, 'amount/amount', data)
@@ -69,7 +70,7 @@ function postPage (req, res, next) {
     return response(req, res, 'amount/amount', data)
   }
 
-  const paymentAmountInPence = parseFloat(paymentAmount) * 100
+  const paymentAmountInPence = convertPoundsAndPenceToPence(paymentAmount)
 
   paymentLinkSession.setAmount(req, product.externalId, paymentAmountInPence)
 

--- a/app/payment-link-v2/amount/amount.controller.test.js
+++ b/app/payment-link-v2/amount/amount.controller.test.js
@@ -194,7 +194,7 @@ describe('Amount Page Controller', () => {
         correlationId: '123',
         product,
         body: {
-          'payment-amount': '10'
+          'payment-amount': '9.95' // deliberately picked because in IEEE 754, 9.95 * 100 is not 995
         }
       }
 
@@ -204,7 +204,7 @@ describe('Amount Page Controller', () => {
 
       controller.postPage(req, res)
 
-      sinon.assert.calledWith(mockPaymentLinkSession.setAmount, req, product.externalId, 1000)
+      sinon.assert.calledWith(mockPaymentLinkSession.setAmount, req, product.externalId, 995)
       sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
     })
 

--- a/app/payment-link-v2/confirm/confirm.controller.js
+++ b/app/payment-link-v2/confirm/confirm.controller.js
@@ -8,6 +8,7 @@ const captcha = require('../../utils/captcha')
 const logger = require('../../utils/logger')(__filename)
 const productsClient = require('../../services/clients/products.client')
 const paymentLinkSession = require('../utils/payment-link-session')
+const { convertPenceToPoundsAndPence } = require('../../utils/currency')
 const { AccountCannotTakePaymentsError } = require('../../errors')
 
 const HIDDEN_FORM_FIELD_ID_REFERENCE_VALUE = 'reference-value'
@@ -51,7 +52,7 @@ async function validateRecaptcha (
 
 function setupPageData (product, sessionReferenceNumber, sessionAmount, referenceProvidedByQueryParams, amountProvidedByQueryParams) {
   const amountAsPence = product.price || sessionAmount
-  const amountTo2DecimalPoint = (parseFloat(amountAsPence) / 100).toFixed(2)
+  const amountTo2DecimalPoint = convertPenceToPoundsAndPence(amountAsPence)
   const amountAsGbp = Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP' }).format(amountTo2DecimalPoint)
   const canChangeAmount = !product.price && !amountProvidedByQueryParams
   const canChangeReference = product.reference_enabled && !referenceProvidedByQueryParams

--- a/app/utils/currency.js
+++ b/app/utils/currency.js
@@ -1,0 +1,57 @@
+'use strict'
+
+/**
+ * Converts a pounds and pence amount, such as
+ * '131.20', to a pence amount, such as 13120,
+ * while avoiding the perils of IEEE floating-
+ * point arithmetic.
+ * 
+ * Acceptable input strings either have two
+ * decimal places, such as '131.20', or are whole
+ * pound amounts, such as '131'.
+ * 
+ * Examples:
+ * 
+ * 131.20 → 13120
+ * 
+ * 131 → 131
+ *
+ * @param {string} poundsAndPenceAmount
+ * @returns {number}
+ */
+function convertPoundsAndPenceToPence (poundsAndPenceAmount) {
+  if (!poundsAndPenceAmount.includes('.')) {
+    poundsAndPenceAmount = poundsAndPenceAmount + '.00'
+  }
+
+  return Number(poundsAndPenceAmount.replace('.', ''))
+}
+
+/**
+ * Converts a pence amount, such as '510', to a
+ * pounds and pence amount, such as '5.10'.
+ * 
+ * This will work fine for all numbers that have
+ * up to 15 significant digits, which is a
+ * ludicrous amount of money (hundreds of
+ * trillions of pounds).
+ * 
+ * Examples:
+ * 
+ * 510 → 5.10
+ * 
+ * 10 → 0.10
+ * 
+ * 1 → 0.01
+ *
+ * @param {string} penceAmount
+ * @returns {string}
+ */
+function convertPenceToPoundsAndPence (penceAmount) {
+  return (parseFloat(penceAmount / 100)).toFixed(2)
+}
+
+module.exports = {
+  convertPoundsAndPenceToPence,
+  convertPenceToPoundsAndPence
+}

--- a/test/unit/utils/currency.test.js
+++ b/test/unit/utils/currency.test.js
@@ -1,0 +1,59 @@
+'use strict'
+
+const { expect } = require('chai')
+
+const { convertPoundsAndPenceToPence, convertPenceToPoundsAndPence } = require('../../../app/utils/currency')
+
+describe('Currency utilities', () => {
+
+  describe('when converting pounds and pence to pence', () => {
+
+    it('should convert 131.20 to 13120', () => {
+      var expected = 13120
+      var actual = convertPoundsAndPenceToPence('131.20')
+      expect(actual).to.equal(expected)
+    })
+
+    it('should convert 131 to 13100', () => {
+      var expected = 13100
+      var actual = convertPoundsAndPenceToPence('131')
+      expect(actual).to.equal(expected)
+    })
+
+    it('should convert 0.10 to 10', () => {
+      var expected = 10
+      var actual = convertPoundsAndPenceToPence('0.10')
+      expect(actual).to.equal(expected)
+    })
+
+    it('should convert 0.01 to 1', () => {
+      var expected = 1
+      var actual = convertPoundsAndPenceToPence('0.01')
+      expect(actual).to.equal(expected)
+    })
+
+  })
+
+  describe('when converting pence to pounds and pence', () => {
+
+    it('should convert 510 to 5.10', () => {
+      var expected = '5.10'
+      var actual = convertPenceToPoundsAndPence(510)
+      expect(actual).to.equal(expected)
+    })
+
+    it('should convert 10 to 0.10', () => {
+      var expected = '0.10'
+      var actual = convertPenceToPoundsAndPence(10)
+      expect(actual).to.equal(expected)
+    })
+
+    it('should convert 1 to 0.01', () => {
+      var expected = '0.01'
+      var actual = convertPenceToPoundsAndPence(1)
+      expect(actual).to.equal(expected)
+    })
+
+  })
+
+})


### PR DESCRIPTION
Fix IEEE 754 floating-point arithmetic errors that sneaked in when we switched to the new payment links flow.

Sometimes we need to convert an amount in pounds and pence to an amount in pence. This might seem simple: multiply it by 100. But IEEE 754 floating-point arithmetic has other ideas…

```
100.45 × 100 = 10045              😀
  9.95 × 100 = 994.9999999999999  🙀
131.20 × 100 = 13119.999999999998 😬
```

Further truncation can mean we end up with an amount that’s a penny out!

Fix this by avoiding multiplication: instead treat the amount as a string and remove the decimal point from it.

(Converting an amount in pence to an amount pounds and pence by dividing by 100 is not as fraught with peril, at least for the monetary amounts we’re likely to be dealing with: see https://stackoverflow.com/q/55127530 for details.)