### PR TITLE
PP-10028 Interpret amounts with only one decimal place correctly

### DIFF
--- a/app/utils/currency.js
+++ b/app/utils/currency.js
@@ -6,25 +6,46 @@
  * while avoiding the perils of IEEE floating-
  * point arithmetic.
  * 
- * Acceptable input strings either have two
- * decimal places, such as '131.20', or are whole
- * pound amounts, such as '131'.
+ * Acceptable input strings are either whole
+ * pound amounts, such as '131', amounts with two
+ * decimal places, such as '131.20', or amounts
+ * with one decimal place, such as '131.2' (which
+ * is equivalent to '131.20').
  * 
  * Examples:
  * 
+ * 131 → 131
+ * 
  * 131.20 → 13120
  * 
- * 131 → 131
+ * 131.2 → 13120
  *
  * @param {string} poundsAndPenceAmount
  * @returns {number}
  */
 function convertPoundsAndPenceToPence (poundsAndPenceAmount) {
-  if (!poundsAndPenceAmount.includes('.')) {
-    poundsAndPenceAmount = poundsAndPenceAmount + '.00'
+  const indexOfLastCharacter = poundsAndPenceAmount.length - 1
+  const indexOfDecimalPoint = poundsAndPenceAmount.lastIndexOf('.')
+  const charactersAfterDecimalPoint = indexOfDecimalPoint !== -1 ? indexOfLastCharacter - indexOfDecimalPoint : 0
+
+  let pounds
+  let pence
+
+  switch (charactersAfterDecimalPoint) {
+    case 2:
+      pounds = poundsAndPenceAmount.slice(0, indexOfDecimalPoint)
+      pence = poundsAndPenceAmount.slice(indexOfDecimalPoint + 1)
+      break
+    case 1:
+      pounds = poundsAndPenceAmount.slice(0, indexOfDecimalPoint)
+      pence = poundsAndPenceAmount.slice(indexOfDecimalPoint + 1).concat('0')
+      break
+    default:
+      pounds = poundsAndPenceAmount
+      pence = '00'
   }
 
-  return Number(poundsAndPenceAmount.replace('.', ''))
+  return Number(pounds.concat(pence))
 }
 
 /**

--- a/test/unit/utils/currency.test.js
+++ b/test/unit/utils/currency.test.js
@@ -32,6 +32,18 @@ describe('Currency utilities', () => {
       expect(actual).to.equal(expected)
     })
 
+    it('should convert 0.7 to 70', () => {
+      var expected = 70
+      var actual = convertPoundsAndPenceToPence('0.7')
+      expect(actual).to.equal(expected)
+    })
+
+    it('should convert 131.2 to 13120', () => {
+      var expected = 13120
+      var actual = convertPoundsAndPenceToPence('131.2')
+      expect(actual).to.equal(expected)
+    })
+
   })
 
   describe('when converting pence to pounds and pence', () => {


### PR DESCRIPTION
Fix regression introduced by commit 81cb20c2ad93ecc48bd73238bfd5da09837ab4f9 where amounts entered with only one decimal place like 0.7 and 12.5 would be wrongly interpreted as 7p and £1.25 respectively rather than the intended 70p and £12.50 respectively.