### PR TITLE
PP-6213 Make reference on payment link success page wrap

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -5,3 +5,7 @@
 img {
   max-width: 100%;
 }
+
+div.govuk-panel--confirmation {
+  overflow-wrap: break-word;
+}


### PR DESCRIPTION
Make it so that the reference on the payment link success page wraps if necessary to prepare us for a world where payment link references can be up to 255 characters.

![image](https://user-images.githubusercontent.com/24316348/188203981-b8ded61e-2530-4a2f-86f7-d399b08d0fed.png)
