### PR TITLE
PP-6213 Increase reference max length from 50 characters to 255

### DIFF
--- a/app/payment-link-v2/reference/reference.controller.test.js
+++ b/app/payment-link-v2/reference/reference.controller.test.js
@@ -15,6 +15,14 @@ const mockResponses = {
   response: responseSpy
 }
 
+const textThatIs255CharactersLong = 'This text contains exactly 255 characters and this is the precise maximum number '
+    + 'allowed for a payment reference and therefore it should pass the validation that checks the text is at most 255 '
+    + 'characters in length and not a single character more than that'
+
+const textThatIs256CharactersLong = 'This is a piece of text that contains exactly 256 characters and this is 1 higher '
+    + 'than 255 characters and as such it will fail any validation that checks if the text has a length of 255 '
+    + 'characters or fewer because it is exactly 1 character longer than that'
+
 let req, res
 
 describe('Reference Page Controller', () => {
@@ -127,7 +135,7 @@ describe('Reference Page Controller', () => {
           correlationId: '123',
           product,
           body: {
-            'payment-reference': 'valid reference'
+            'payment-reference': textThatIs255CharactersLong
           }
         }
 
@@ -137,7 +145,7 @@ describe('Reference Page Controller', () => {
 
         controller.postPage(req, res)
 
-        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, 'valid reference')
+        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, textThatIs255CharactersLong)
         sinon.assert.calledWith(res.redirect, '/pay/an-external-id/amount')
       })
 
@@ -146,7 +154,7 @@ describe('Reference Page Controller', () => {
           correlationId: '123',
           product,
           body: {
-            'payment-reference': 'valid reference'
+            'payment-reference': textThatIs255CharactersLong
           },
           query: {
             change: 'true'
@@ -159,7 +167,7 @@ describe('Reference Page Controller', () => {
 
         controller.postPage(req, res)
 
-        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, 'valid reference')
+        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, textThatIs255CharactersLong)
         sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
       })
 
@@ -168,7 +176,7 @@ describe('Reference Page Controller', () => {
           correlationId: '123',
           product,
           body: {
-            'payment-reference': 'valid reference'
+            'payment-reference': textThatIs255CharactersLong
           },
           session: {}
         }
@@ -183,7 +191,7 @@ describe('Reference Page Controller', () => {
 
         controller.postPage(req, res)
 
-        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, 'valid reference')
+        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, textThatIs255CharactersLong)
         sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
       })
 
@@ -278,12 +286,12 @@ describe('Reference Page Controller', () => {
         expect(pageData.errors['payment-reference']).to.equal('Enter your invoice number')
       })
 
-      it('when a reference > 50 is entered, it should display an error message with the `reference_label` and the back link correctly', () => {
+      it('when a reference > 255 is entered, it should display an error message with the `reference_label` and the back link correctly', () => {
         req = {
           correlationId: '123',
           product,
           body: {
-            'payment-reference': 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1'
+            'payment-reference': textThatIs256CharactersLong
           }
         }
 
@@ -352,7 +360,7 @@ describe('Reference Page Controller', () => {
           correlationId: '123',
           product,
           body: {
-            'payment-reference': 'valid reference'
+            'payment-reference': textThatIs255CharactersLong
           }
         }
 
@@ -362,7 +370,7 @@ describe('Reference Page Controller', () => {
 
         controller.postPage(req, res)
 
-        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, 'valid reference')
+        sinon.assert.calledWith(mockPaymentLinkSession.setReference, req, product.externalId, textThatIs255CharactersLong)
         sinon.assert.calledWith(res.redirect, '/pay/an-external-id/confirm')
       })
     })

--- a/app/payment-link-v2/reference/reference.njk
+++ b/app/payment-link-v2/reference/reference.njk
@@ -53,7 +53,6 @@
           html: product.reference_hint | striptags(true) | escape | nl2br if product.reference_hint else false
         },
         value: reference,
-        classes: "govuk-input--width-20",
         spellcheck: false,
         attributes: {
           'data-cy': 'input'

--- a/app/utils/validation/form-validations.js
+++ b/app/utils/validation/form-validations.js
@@ -2,6 +2,7 @@
 
 // Constants
 const MAX_AMOUNT = 100000
+const MAX_REFERENCE_LENGTH = 255
 
 const validationMessageKeys = {
   enterAnAmountInPounds: 'paymentLinksV2.fieldValidation.enterAnAmountInPounds',
@@ -58,7 +59,7 @@ function isEmptyReference (value) {
 }
 
 function isReferenceTooLong (value) {
-  if (value.trim().length > 50) {
+  if (value.trim().length > MAX_REFERENCE_LENGTH) {
     return validationMessageKeys.referenceMustBeLessThanOrEqual50Chars
   } else {
     return false

--- a/app/utils/validation/form-validations.test.js
+++ b/app/utils/validation/form-validations.test.js
@@ -4,6 +4,14 @@ const { expect } = require('chai')
 
 const validations = require('./form-validations')
 
+const textThatIs255CharactersLong = 'This text contains exactly 255 characters and this is the precise maximum number '
+    + 'allowed for a payment reference and therefore it should pass the validation that checks the text is at most 255 '
+    + 'characters in length and not a single character more than that'
+
+const textThatIs256CharactersLong = 'This is a piece of text that contains exactly 256 characters and this is 1 higher '
+    + 'than 255 characters and as such it will fail any validation that checks if the text has a length of 255 '
+    + 'characters or fewer because it is exactly 1 character longer than that'
+
 describe('Server side form validations', () => {
   describe('amount validation', () => {
     it('when valid amount entered, should return valid=true', () => {
@@ -34,7 +42,7 @@ describe('Server side form validations', () => {
 
   describe('reference validation', () => {
     it('when valid reference is entered, should return valid=true', () => {
-      expect(validations.validateReference('test reference').valid).to.be.true // eslint-disable-line
+      expect(validations.validateReference(textThatIs255CharactersLong).valid).to.be.true // eslint-disable-line
     })
 
     it('when no amount entered, should return valid=false and the correct error message key', () => {
@@ -45,7 +53,7 @@ describe('Server side form validations', () => {
     })
 
     it('when a reference is too long, should return valid=false and correct error message key', () => {
-      expect(validations.validateReference('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1')).to.deep.equal({
+      expect(validations.validateReference(textThatIs256CharactersLong)).to.deep.equal({
         valid: false,
         messageKey: 'paymentLinksV2.fieldValidation.referenceMustBeLessThanOrEqual50Chars'
       })

--- a/test/cypress/integration/payment-link-v2/reference-and-reference-confirm.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/reference-and-reference-confirm.cy.test.js
@@ -6,6 +6,10 @@ const serviceStubs = require('../../stubs/service-stubs')
 const gatewayAccountId = 666
 const productExternalId = 'a-product-id'
 
+const textThatIs256CharactersLong = 'This is a piece of text that contains exactly 256 characters and this is 1 higher '
+    + 'than 255 characters and as such it will fail any validation that checks if the text has a length of 255 '
+    + 'characters or fewer because it is exactly 1 character longer than that'
+
 describe('Reference and reference confirm page', () => {
   describe('when the Payment Link has no price', () => {
     beforeEach(() => {
@@ -42,7 +46,7 @@ describe('Reference and reference confirm page', () => {
 
       it('when an reference is entered that is too long, should display an error', () => {
         Cypress.Cookies.preserveOnce('session')
-        cy.get('[data-cy=input]').type('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1', { delay: 0 })
+        cy.get('[data-cy=input]').type(textThatIs256CharactersLong, { delay: 0 })
         cy.get('[data-cy=button]').click()
 
         cy.get('[data-cy=error-summary] h2').should('contain', 'There is a problem')

--- a/test/cypress/integration/payment-link-v2/welsh-reference.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/welsh-reference.cy.test.js
@@ -6,6 +6,10 @@ const serviceStubs = require('../../stubs/service-stubs')
 const gatewayAccountId = 666
 const productExternalId = 'a-product-id'
 
+const textThatIs256CharactersLong = 'This is a piece of text that contains exactly 256 characters, which is 1 higher '
+    + 'than 255 characters, and as such it will fail any validation that checks if some text has a length of 255 '
+    + 'characters or fewer because it is exactly 1 character longer than that'
+
 describe('Welsh - reference page', () => {
   describe('when the Payment Link has no price', () => {
     beforeEach(() => {
@@ -43,7 +47,7 @@ describe('Welsh - reference page', () => {
 
       it('when an reference is entered that is too long, should display an error', () => {
         Cypress.Cookies.preserveOnce('session')
-        cy.get('[data-cy=input]').type('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1', { delay: 0 })
+        cy.get('[data-cy=input]').type(textThatIs256CharactersLong, { delay: 0 })
         cy.get('[data-cy=button]').click()
 
         cy.get('[data-cy=error-summary] h2').should('contain', 'Mae yna broblem')


### PR DESCRIPTION
Allow the reference number to be 255 characters long to match what our payments in general allow, rather than just 50.

Also make the field where users enter their reference full-size to accommodate such jumbo references.

Do not change the validation message just yet: this is because while this change is being released there will be a period where some servers are allowing 50 characters and some 255 and it will confuse a user if they hit a server that only allows 50 and a server that gives the 255 validation message. So we’ll just pretend it’s 50 for a little longer.

![image](https://user-images.githubusercontent.com/24316348/188421306-fe545c9a-33f5-47a6-a80f-7893dfe2f04b.png)
![image](https://user-images.githubusercontent.com/24316348/188421356-e1183583-ede1-4e8b-ab83-19ee8e4aae31.png)
