### PR TITLE
PP-6213 Change reference too long error message to state 255 limit

### DIFF
--- a/app/payment-links/reference/reference.controller.test.js
+++ b/app/payment-links/reference/reference.controller.test.js
@@ -302,7 +302,7 @@ describe('Reference Page Controller', () => {
           }
         }
 
-        res.locals.__p.withArgs('paymentLinks.fieldValidation.referenceMustBeLessThanOrEqual50Chars').returns('%s must be less than or equal to 50 characters')
+        res.locals.__p.withArgs('paymentLinks.fieldValidation.referenceTooLong').returns('%s must be less than or equal to 255 characters')
 
         controller.postPage(req, res)
 
@@ -311,7 +311,7 @@ describe('Reference Page Controller', () => {
         const pageData = mockResponses.response.args[0][3]
         expect(pageData.backLinkHref).to.equal('/pay/an-external-id')
 
-        expect(pageData.errors['payment-reference']).to.equal('Invoice number must be less than or equal to 50 characters')
+        expect(pageData.errors['payment-reference']).to.equal('Invoice number must be less than or equal to 255 characters')
       })
 
       it('when an invalid reference is entered and the change query parameter is present, it should display an error ' +

--- a/app/utils/validation/form-validations.js
+++ b/app/utils/validation/form-validations.js
@@ -9,7 +9,7 @@ const validationMessageKeys = {
   enterAnAmountInTheCorrectFormat: 'paymentLinks.fieldValidation.enterAnAmountInTheCorrectFormat',
   enterAnAmountUnderMaxAmount: 'paymentLinks.fieldValidation.enterAnAmountUnderMaxAmount',
   enterAReference: 'paymentLinks.fieldValidation.enterAReference',
-  referenceMustBeLessThanOrEqual50Chars: 'paymentLinks.fieldValidation.referenceMustBeLessThanOrEqual50Chars',
+  referenceTooLong: 'paymentLinks.fieldValidation.referenceTooLong',
   referenceCantUseInvalidChars: 'paymentLinks.fieldValidation.referenceCantUseInvalidChars'
 }
 
@@ -60,7 +60,7 @@ function isEmptyReference (value) {
 
 function isReferenceTooLong (value) {
   if (value.trim().length > MAX_REFERENCE_LENGTH) {
-    return validationMessageKeys.referenceMustBeLessThanOrEqual50Chars
+    return validationMessageKeys.referenceTooLong
   } else {
     return false
   }

--- a/app/utils/validation/form-validations.test.js
+++ b/app/utils/validation/form-validations.test.js
@@ -55,7 +55,7 @@ describe('Server side form validations', () => {
     it('when a reference is too long, should return valid=false and correct error message key', () => {
       expect(validations.validateReference(textThatIs256CharactersLong)).to.deep.equal({
         valid: false,
-        messageKey: 'paymentLinks.fieldValidation.referenceMustBeLessThanOrEqual50Chars'
+        messageKey: 'paymentLinks.fieldValidation.referenceTooLong'
       })
     })
 

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -92,7 +92,7 @@
       "enterAnAmountInTheCorrectFormat": "Cofnodwch swm mewn punnoedd a cheiniogau gan ddefnyddio digidau a phwynt degol, fel 123.45 neu 156.00",
       "enterAnAmountUnderMaxAmount": "Cofnodwch swm sy’n £100,000 neu lai",
       "enterAReference": "Mae’n rhaid i chi gofnodi’ch %s",
-      "referenceMustBeLessThanOrEqual50Chars": "Mae’n rhaid i %s fod yn 50 nod neu lai",
+      "referenceTooLong": "Mae’n rhaid i %s fod yn 255 nod neu lai",
       "referenceCantUseInvalidChars": "Mae’n rhaid i %s beidio â chynnwys unrhyw un o’r nodau canlynol < > ; : ` ( ) \" ’ = | \",\" ~ [ ]",
       "youMustSelectIAmNotARobot": "Mae’n rhaid i chi ddewis ’dw i ddim yn robot’ cyn symud ymlaen at dalu"
     },

--- a/locales/en.json
+++ b/locales/en.json
@@ -92,7 +92,7 @@
       "enterAnAmountInTheCorrectFormat": "Enter an amount in pounds and pence using digits and a decimal point, like 123.45 or 156.00",
       "enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or less",
       "enterAReference": "You must enter your %s",
-      "referenceMustBeLessThanOrEqual50Chars": "%s must be 50 characters or fewer",
+      "referenceTooLong": "%s must be 255 characters or fewer",
       "referenceCantUseInvalidChars": "%s must not include any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
       "youMustSelectIAmNotARobot": "You must select 'I’m not a robot' before proceeding to payment."
     },

--- a/test/cypress/integration/payment-link-v2/reference-and-reference-confirm.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/reference-and-reference-confirm.cy.test.js
@@ -52,10 +52,10 @@ describe('Reference and reference confirm page', () => {
         cy.get('[data-cy=error-summary] h2').should('contain', 'There is a problem')
 
         cy.get('[data-cy=error-summary] a')
-          .should('contain', 'Invoice number must be 50 characters or fewer')
+          .should('contain', 'Invoice number must be 255 characters or fewer')
           .should('have.attr', 'href', '#payment-reference')
 
-        cy.get('[data-cy=error-message]').should('contain', 'Invoice number must be 50 characters or fewer')
+        cy.get('[data-cy=error-message]').should('contain', 'Invoice number must be 255 characters or fewer')
       })
 
       it('when an reference is entered that looks like a card number, should go to the `reference confirm` page', () => {

--- a/test/cypress/integration/payment-link-v2/welsh-reference.cy.test.js
+++ b/test/cypress/integration/payment-link-v2/welsh-reference.cy.test.js
@@ -53,10 +53,10 @@ describe('Welsh - reference page', () => {
         cy.get('[data-cy=error-summary] h2').should('contain', 'Mae yna broblem')
 
         cy.get('[data-cy=error-summary] a')
-          .should('contain', 'Mae’n rhaid i rhif anfoneb fod yn 50 nod neu lai')
+          .should('contain', 'Mae’n rhaid i rhif anfoneb fod yn 255 nod neu lai')
           .should('have.attr', 'href', '#payment-reference')
 
-        cy.get('[data-cy=error-message]').should('contain', 'Mae’n rhaid i rhif anfoneb fod yn 50 nod neu lai')
+        cy.get('[data-cy=error-message]').should('contain', 'Mae’n rhaid i rhif anfoneb fod yn 255 nod neu lai')
       })
     })
   })


### PR DESCRIPTION
We now allow 255 characters for references for payment links (previously 50) so update the error message.
![image](https://user-images.githubusercontent.com/24316348/188454783-b2679569-6e9a-4cfa-aea4-2010497efda4.png)
