### PR TITLE
PP-6213 Reference on payment link success page: use word-wrap too

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -7,5 +7,6 @@ img {
 }
 
 div.govuk-panel--confirmation {
+  word-wrap: break-word;
   overflow-wrap: break-word;
 }


### PR DESCRIPTION
Use `word-wrap: break-word` in addition to `overflow-wrap: break-word` for the reference on the payment link success page to support browsers that do not support `overflow-wrap` (notably IE11).