### PR TITLE
PP-10116 update secrets baseline, pre-commit conf

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,14 @@ permissions:
   contents: read
 
 jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8
+      - name: Detect secrets
+        uses: alphagov/pay-ci/actions/detect-secrets@master
+
   version:
     runs-on: ubuntu-latest
     name: Parse versions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
-- repo: https://github.com/Yelp/detect-secrets
-  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
-  hooks:
-    - id: detect-secrets
-      args: ['--baseline', '.secrets.baseline']
-      exclude: package.lock.json
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        args: [ '--baseline', '.secrets.baseline' ]
+        exclude: ^package-lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,11 +1,14 @@
 {
-  "version": "1.1.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
     },
     {
       "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
@@ -18,8 +21,14 @@
       "name": "CloudantDetector"
     },
     {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
-      "limit": 3
+      "limit": 3.0
     },
     {
       "name": "IbmCloudIamDetector"
@@ -38,13 +47,22 @@
       "name": "MailchimpDetector"
     },
     {
+      "name": "NpmDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "SendGridDetector"
     },
     {
       "name": "SlackDetector"
     },
     {
       "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
     },
     {
       "name": "StripeDetector"
@@ -56,10 +74,6 @@
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -91,161 +105,98 @@
     },
     {
       "path": "detect_secrets.filters.heuristic.is_templated_secret"
-    },
-    {
-      "path": "detect_secrets.filters.regex.should_exclude_file",
-      "pattern": [
-        "package-lock.json"
-      ]
     }
   ],
   "results": {
-    ".pre-commit-config.yaml": [
+    "app/clients/products/payment.create.pact.test.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": ".pre-commit-config.yaml",
-        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
+        "filename": "app/clients/products/payment.create.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 3
+        "line_number": 20
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/clients/products/payment.create.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 20
       }
     ],
-    "test/unit/client/product.client/payment/payment.create.pact.test.js": [
+    "app/clients/products/payment.get-by-payment-external-id.pact.test.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/payment/payment.create.pact.test.js",
+        "filename": "app/clients/products/payment.get-by-payment-external-id.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 20
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "app/clients/products/payment.get-by-payment-external-id.pact.test.js",
+        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
+        "is_verified": false,
+        "line_number": 20
+      }
+    ],
+    "app/clients/products/payment.get-by-product-external-id.pact.test.js": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "app/clients/products/payment.get-by-product-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
         "line_number": 21
       },
       {
         "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/payment/payment.create.pact.test.js",
+        "filename": "app/clients/products/payment.get-by-product-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
         "line_number": 21
       }
     ],
-    "test/unit/client/product.client/payment/payment.get-by-payment-external-id.pact.test.js": [
+    "app/clients/products/product.get-by-gateway-account-id.pact.test.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/payment/payment.get-by-payment-external-id.pact.test.js",
+        "filename": "app/clients/products/product.get-by-gateway-account-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/payment/payment.get-by-payment-external-id.pact.test.js",
+        "filename": "app/clients/products/product.get-by-gateway-account-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 21
+        "line_number": 20
       }
     ],
-    "test/unit/client/product.client/payment/payment.product.get-by-product-external-id.pact.test.js": [
+    "app/clients/products/product.get-by-product-external-id.pact.test.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/payment/payment.product.get-by-product-external-id.pact.test.js",
+        "filename": "app/clients/products/product.get-by-product-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 20
       },
       {
         "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/payment/payment.product.get-by-product-external-id.pact.test.js",
+        "filename": "app/clients/products/product.get-by-product-external-id.pact.test.js",
         "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 20
       }
     ],
-    "test/unit/client/product.client/product/payment.create.pact.test.js": [
+    "app/payment/payment-complete.controller.test.js": [
       {
         "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/product/payment.create.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/product/payment.create.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 21
-      }
-    ],
-    "test/unit/client/product.client/product/delete.pact.test.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/product/delete.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/product/delete.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    "test/unit/client/product.client/product/disable.pact.test.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/product/disable.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 19
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/product/disable.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
-    "test/unit/client/product.client/product/product.get-by-gateway-account-id.pact.test.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/product/product.get-by-gateway-account-id.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/product/product.get-by-gateway-account-id.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 21
-      }
-    ],
-    "test/unit/client/product.client/product/payment.product.get-by-product-external-id.pact.test.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/client/product.client/product/payment.product.get-by-product-external-id.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 21
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "test/unit/client/product.client/product/payment.product.get-by-product-external-id.pact.test.js",
-        "hashed_secret": "98072afbff3edfd36d609674546a2b8f9261383e",
-        "is_verified": false,
-        "line_number": 21
-      }
-    ],
-    "test/unit/controllers/payment-complete.controller.test.js": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "test/unit/controllers/payment-complete.controller.test.js",
+        "filename": "app/payment/payment-complete.controller.test.js",
         "hashed_secret": "cb9f57fdfdc1628c165407930d5cfb5fe33f7ade",
         "is_verified": false,
         "line_number": 121
       }
     ]
   },
-  "generated_at": "2022-08-26T10:06:48Z"
+  "generated_at": "2022-11-08T17:36:58Z"
 }


### PR DESCRIPTION
### WHAT

- added a new github action to run `detect-secrets`
- updated the pre-commit config to update the detect-secrets hook to version `1.4`
- rebaselined the repository's secrets baseline

#### For reviewers

- ensure your local version of `detect-secrets` matches the latest version in use on this branch
- run `detect-secrets scan` and ensure output matches the latest `.secrets.baseline`, the only change should be the generated timestamp