### PR TITLE
ZD-5142738: Bump pay-js-commons with npm upgrade pay-js-commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "3.8.2",
+        "@govuk-pay/pay-js-commons": "3.8.3",
         "@sentry/node": "7.29.0",
         "body-parser": "1.20.x",
         "chokidar": "^3.5.3",
@@ -44,7 +44,7 @@
         "@snyk/protect": "^1.1081.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^9.7.0",
         "dotenv": "^16.0.3",
         "envfile": "^5.2.0",
@@ -1850,12 +1850,12 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.2.tgz",
-      "integrity": "sha512-Ezpex31o5tcdQsy7jyBif4HPFUPnNRBUpt8N55/sDcaUA/QQ9wozT2nwYXYF6XwkW4cRrJL6DnrMxy0IGIFFjg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.3.tgz",
+      "integrity": "sha512-eToZ6HDyneXHYld3YrjEMQLzfYrqDwP9/JAP0auZudjA87BVCVu9LnMqAmnbFrokqajiP0kPQ2xDJ37CBLn8rw==",
       "dependencies": {
         "lodash": "4.17.21",
-        "moment-timezone": "0.5.38",
+        "moment-timezone": "0.5.40",
         "rfc822-validate": "1.0.0",
         "slugify": "1.6.5",
         "winston": "3.8.2"
@@ -11589,9 +11589,9 @@
       }
     },
     "node_modules/moment-timezone": {
-      "version": "0.5.38",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.38.tgz",
-      "integrity": "sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==",
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.40.tgz",
+      "integrity": "sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==",
       "dependencies": {
         "moment": ">= 2.9.0"
       },
@@ -19303,12 +19303,12 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.2.tgz",
-      "integrity": "sha512-Ezpex31o5tcdQsy7jyBif4HPFUPnNRBUpt8N55/sDcaUA/QQ9wozT2nwYXYF6XwkW4cRrJL6DnrMxy0IGIFFjg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.3.tgz",
+      "integrity": "sha512-eToZ6HDyneXHYld3YrjEMQLzfYrqDwP9/JAP0auZudjA87BVCVu9LnMqAmnbFrokqajiP0kPQ2xDJ37CBLn8rw==",
       "requires": {
         "lodash": "4.17.21",
-        "moment-timezone": "0.5.38",
+        "moment-timezone": "0.5.40",
         "rfc822-validate": "1.0.0",
         "slugify": "1.6.5",
         "winston": "3.8.2"
@@ -26790,9 +26790,9 @@
       "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moment-timezone": {
-      "version": "0.5.38",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.38.tgz",
-      "integrity": "sha512-nMIrzGah4+oYZPflDvLZUgoVUO4fvAqHstvG3xAUnMolWncuAiLDWNnJZj6EwJGMGfb1ZcuTFE6GI3hNOVWI/Q==",
+      "version": "0.5.40",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.40.tgz",
+      "integrity": "sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==",
       "requires": {
         "moment": ">= 2.9.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "3.8.2",
+    "@govuk-pay/pay-js-commons": "3.8.3",
     "@sentry/node": "7.29.0",
     "body-parser": "1.20.x",
     "chokidar": "^3.5.3",


### PR DESCRIPTION
Update pay-js-commons in package-lock.json and then ran `npm upgrade pay-js-commons`.