### PR TITLE
ZD-5142738 bump commons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "3.8.5",
+        "@govuk-pay/pay-js-commons": "3.8.6",
         "@sentry/node": "7.29.0",
         "body-parser": "1.20.x",
         "chokidar": "^3.5.3",
@@ -44,7 +44,7 @@
         "@snyk/protect": "^1.1082.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^9.7.0",
         "dotenv": "^16.0.3",
         "envfile": "^5.2.0",
@@ -1850,9 +1850,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.5.tgz",
-      "integrity": "sha512-oRICWXwwcatw/itGHS+gOznM7BLyY/P8hFZtk5Xyry9DHNmfQCp8siOpc+aG/qhk4BCKf8NoqBLGxlvERq1beg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.6.tgz",
+      "integrity": "sha512-Rb0gc7td3kB/q57KbT85oQTj2u4TVgTfJ/0+nCstckqh6Jr7BfbXePKyMbxrTFWUoUVja68n29qwztk7s2kHvw==",
       "dependencies": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.40",
@@ -19303,9 +19303,9 @@
       }
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.5.tgz",
-      "integrity": "sha512-oRICWXwwcatw/itGHS+gOznM7BLyY/P8hFZtk5Xyry9DHNmfQCp8siOpc+aG/qhk4BCKf8NoqBLGxlvERq1beg==",
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-3.8.6.tgz",
+      "integrity": "sha512-Rb0gc7td3kB/q57KbT85oQTj2u4TVgTfJ/0+nCstckqh6Jr7BfbXePKyMbxrTFWUoUVja68n29qwztk7s2kHvw==",
       "requires": {
         "lodash": "4.17.21",
         "moment-timezone": "0.5.40",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "3.8.5",
+    "@govuk-pay/pay-js-commons": "3.8.6",
     "@sentry/node": "7.29.0",
     "body-parser": "1.20.x",
     "chokidar": "^3.5.3",


### PR DESCRIPTION
### WHAT

- bump `js-commons` 3.8.5 -> 3.8.6
