### PR TITLE
PP-10692: Upgrade base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:16.18.1-alpine3.16@sha256:868e2b6c8923d87a4bbfb157d757898061c9000aaaedf64472074fa7b62d0e72 as builder
+FROM node:16.19.1-alpine3.17@sha256:25828d5c4ae9824273db9ca2e923da2d29bbae78f534e979f09eb99a2e812e94 as builder
 
 ### Needed to run pact-mock-service
 COPY sgerrand.rsa.pub /etc/apk/keys/sgerrand.rsa.pub
 RUN ["apk", "--no-cache", "add", "ca-certificates", "python3", "build-base", "bash", "ruby"]
-RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && apk add --no-cache glibc-2.28-r0.apk && rm -f glibc-2.28-r0.apk
+RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.28-r0/glibc-2.28-r0.apk && apk add --force-overwrite --no-cache glibc-2.28-r0.apk && rm -f glibc-2.28-r0.apk
 ###
 
 WORKDIR /app

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@snyk/protect": "^1.1104.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^9.7.0",
         "dotenv": "^16.0.3",
         "envfile": "^5.2.0",


### PR DESCRIPTION
[Image layer details](https://hub.docker.com/layers/library/node/16.19.1-alpine3.17/images/sha256-25828d5c4ae9824273db9ca2e923da2d29bbae78f534e979f09eb99a2e812e94?context=explore).

Without the `--force-overwrite` flag we get the following when running in a
local docker node 16.19.1 image:
```
/ # apk add --no-cache glibc-2.28-r0.apk
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/main/aarch64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.17/community/aarch64/APKINDEX.tar.gz
(1/1) Installing glibc (2.28-r0)
ERROR: glibc-2.28-r0: trying to overwrite etc/nsswitch.conf owned by alpine-baselayout-data-3.4.0-r0.
1 error; 14 MiB in 18 packages
```
The fix to add the `--force-overwrite` is found at
https://github.com/sgerrand/alpine-pkg-glibc/issues/185.