### PR TITLE
PP-10863 Do not autocapitalize ref and omit spellcheck for amount

### DIFF
--- a/app/payment-links/amount/amount.njk
+++ b/app/payment-links/amount/amount.njk
@@ -53,7 +53,6 @@
           text: "£"
         },
         classes: "govuk-input--width-5",
-        spellcheck: false,
         attributes: { 'data-cy': 'input' }
       }) }}
       

--- a/app/payment-links/reference/reference.njk
+++ b/app/payment-links/reference/reference.njk
@@ -55,6 +55,7 @@
         value: reference,
         spellcheck: false,
         attributes: {
+          'autocapitalize': 'none',
           'data-cy': 'input'
         }
       }) }}


### PR DESCRIPTION
On the page where the user enters their payment reference, set `autocapitalize="none"` because references can have many formats and capitalising the first letter may not be appropriate.

On the page where the user enters the amount to pay, remove the `spellcheck="false"` attribute — nobody should be putting anything that can be considered a mispelling into this input so it does not matter whether or not the browser applies spelling checking.