### PR TITLE
PP-10887 Add novalidate to all forms

### DIFF
--- a/app/payment-links/amount/amount.njk
+++ b/app/payment-links/amount/amount.njk
@@ -29,7 +29,7 @@
       }
     }) }}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({

--- a/app/payment-links/confirm/confirm.njk
+++ b/app/payment-links/confirm/confirm.njk
@@ -41,7 +41,7 @@
 
       {% include "./_summary-list.njk" %}
 
-      <form method="post" data-cy="form">
+      <form method="post" data-cy="form" novalidate>
         <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
         {% if productReferenceLabel %}

--- a/app/payment-links/reference-confirm/reference-confirm.njk
+++ b/app/payment-links/reference-confirm/reference-confirm.njk
@@ -42,7 +42,7 @@
 
     {% set radioErrorMessage = { text: errors['confirm-reference'], attributes: { 'data-cy': 'error-message'} } if errors['confirm-reference'] %}  
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukRadios({

--- a/app/payment-links/reference/reference.njk
+++ b/app/payment-links/reference/reference.njk
@@ -29,7 +29,7 @@
       }
     }) }}
 
-    <form method="post">
+    <form method="post" novalidate>
       <input id="csrf" name="csrfToken" type="hidden" value="{{ csrf }}"/>
 
       {{ govukInput({


### PR DESCRIPTION
Add a `novalidate` attribute to all `form` elements to disable built-in HTML5 browser client-side validation.

The Design System says to do this at https://design-system.service.gov.uk/patterns/validation/:

> HTML5 validation is a type of client side validation built into browsers. Do not use it because:
> 
> • the visual style, placement and content of HTML5 error messages cannot be made consistent with the GOV.UK Design System
> • we know that the GOV.UK Design System error message and error summary components are accessible
> 
> To turn off HTML5 validation, add ‘novalidate’ to your form tags.

Strictly speaking, this only needs to be done for forms that contain validatable fields (none of the ones in products-ui seem to need it) but it’s easiest just to add it to all `form` elements.