### PR TITLE
PP-10863 Add spellcheck="false" back to amount input

### DIFF
--- a/app/payment-links/amount/amount.njk
+++ b/app/payment-links/amount/amount.njk
@@ -53,6 +53,7 @@
           text: "£"
         },
         classes: "govuk-input--width-5",
+        spellcheck: false,
         attributes: { 'data-cy': 'input' }
       }) }}
       


### PR DESCRIPTION
Turns out the GOV.UK Design System recommends spellcheck=false for decimal inputs, so add it back to the amount input.

This partially reverts commit 87c9a8ae7d8557b072d356b92c06c3457122df3e.