### PR TITLE
PP-10951: Update qs to v6.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14285,11 +14285,17 @@
       }
     },
     "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
       "engines": {
         "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/request/node_modules/uuid": {
@@ -28811,7 +28817,7 @@
         "mime-types": "~2.1.19",
         "oauth-sign": "~0.9.0",
         "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
+        "qs": "6.11.1",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
@@ -28850,9 +28856,12 @@
           }
         },
         "qs": {
-          "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-          "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+          "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
+          "requires": {
+            "side-channel": "^1.0.4"
+          }
         },
         "uuid": {
           "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -129,5 +129,10 @@
     "stylelint-order": "^6.0.3",
     "supertest": "^6.3.3"
   },
+  "overrides": {
+    "request": {
+      "qs": "6.11.1"
+    }
+  },
   "snyk": true
 }


### PR DESCRIPTION
[qs](https://www.npmjs.com/package/qs) is a dependency of `request`, [which is no longer maintained](https://www.npmjs.com/package/request). So here we've added an override to get the latest compatible version of `qs`.
