### PR TITLE
BAU: Resolve ejs/mountebank-formatters conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@snyk/protect": "^1.1171.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^9.7.0",
         "dotenv": "^16.0.3",
         "envfile": "^5.2.0",
@@ -11900,16 +11900,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/mountebank-formatters/node_modules/ejs": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-      "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/mountebank-formatters/node_modules/fs-extra": {
@@ -27304,16 +27294,10 @@
       "integrity": "sha512-zNFk187W4crPPyGKWIZwkZItdf5B3+UtdSqkDcRwKg9BZRMNoNIBGg6y29kbWKFKh/neFLx9XcCXx06z7AWalA==",
       "dev": true,
       "requires": {
-        "ejs": "2.7.4",
+        "ejs": "3.1.8",
         "fs-extra": "9.0.1"
       },
       "dependencies": {
-        "ejs": {
-          "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
-          "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
-          "dev": true
-        },
         "fs-extra": {
           "version": "9.0.1",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,9 @@
   "overrides": {
     "request": {
       "qs": "6.11.1"
+    },
+    "mountebank-formatters": {
+      "ejs": "3.1.8"
     }
   },
   "snyk": true


### PR DESCRIPTION
There has been a long running issue on `ejs`, one of the dev dependences (see https://github.com/alphagov/pay-products-ui/security/dependabot/28). Solving this should reduce noise in our dependency alerts.

The tests still pass OK when overriding `ejs` to 3.1.8.

