### PR TITLE
PP-10875 Remove request library usage from cypress tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "@pact-foundation/pact": "^9.18.1",
         "@pact-foundation/pact-node": "10.17.7",
         "@snyk/protect": "^1.1171.x",
+        "axios": "^1.4.0",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
         "chokidar-cli": "latest",
@@ -2396,6 +2397,30 @@
         "node": ">=4"
       }
     },
+    "node_modules/@pact-foundation/pact/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@pact-foundation/pact/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@selderee/plugin-htmlparser2": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.6.0.tgz",
@@ -3271,13 +3296,14 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
@@ -3293,6 +3319,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
       "version": "0.4.3",
@@ -19840,6 +19872,29 @@
         "pkginfo": "^0.4.1",
         "ramda": "^0.27.2",
         "randexp": "^0.5.3"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.27.2",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+          "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.9",
+            "form-data": "^4.0.0"
+          }
+        },
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "@pact-foundation/pact-node": {
@@ -20600,13 +20655,14 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       },
       "dependencies": {
         "form-data": {
@@ -20619,6 +20675,12 @@
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
           }
+        },
+        "proxy-from-env": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+          "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "@pact-foundation/pact": "^9.18.1",
     "@pact-foundation/pact-node": "10.17.7",
     "@snyk/protect": "^1.1171.x",
+    "axios": "^1.4.0",
     "chai": "^4.3.7",
     "cheerio": "^1.0.0-rc.12",
     "chokidar-cli": "latest",

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -7,7 +7,7 @@
 
 'use strict'
 
-const request = require('request-promise-native')
+const axios = require('axios')
 
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
@@ -23,48 +23,45 @@ module.exports = (on, config) => {
      * the same call.
      */
     setupStubs (stubs) {
-      return request({
-        method: 'POST',
-        url: mountebankImpostersUrl,
-        json: true,
-        body: {
+      return axios.post(mountebankImpostersUrl,
+        {
           port: config.env.MOUNTEBANK_IMPOSTERS_PORT,
           protocol: 'http',
           stubs
-        }
-      })
+        })
+        .then(function () { return ''})
+        .catch(function (error) { throw error})
     },
     /**
      * Makes a request to Mountebank to delete the existing Imposter along with all stubs that have been set up.
      */
     clearStubs () {
-      return request.delete(mountebankImpostersUrl)
+      return axios.delete(mountebankImpostersUrl)
+        .then(function () { return ''})
+        .catch(function (error) { throw error})
     },
     /**
      * Makes a request to Mountebank to verify that stubs have been called the expected number of times
      */
     verifyStubs () {
-      return request({
-        method: 'GET',
-        url: `${mountebankImpostersUrl}/${config.env.MOUNTEBANK_IMPOSTERS_PORT}`,
-        json: true
-      }).then(response => {
-        response.stubs.forEach((stub) => {
-          // NOTE: if the "verifyCalledTimes" is specified for a stub, we will attempt to verify
-          // for all `it` blocks the stub is setup for, and the counter is reset for every `it`.
-          if (stub.verifyCalledTimes) {
-            // the matches array is added to stubs only when Mountebank is run with the --debug flag
-            const timesCalled = (stub.matches && stub.matches.length) || 0
-            if (timesCalled !== stub.verifyCalledTimes) {
-              throw new Error(`Expected stub '${stub.name}' to be called ${stub.verifyCalledTimes} times, but was called ${timesCalled} times`)
+      return axios.get(`${mountebankImpostersUrl}/${config.env.MOUNTEBANK_IMPOSTERS_PORT}`)
+        .then(function (response){
+          response.data.stubs.forEach((stub) => {
+            // NOTE: if the "verifyCalledTimes" is specified for a stub, we will attempt to verify
+            // for all `it` blocks the stub is setup for, and the counter is reset for every `it`.
+            if (stub.verifyCalledTimes) {
+              // the matches array is added to stubs only when Mountebank is run with the --debug flag
+              const timesCalled = (stub.matches && stub.matches.length) || 0
+              if (timesCalled !== stub.verifyCalledTimes) {
+                throw new Error(`Expected stub '${stub.name}' to be called ${stub.verifyCalledTimes} times, but was called ${timesCalled} times`)
+              }
             }
-          }
-        })
+          })
 
-        return null
-      })
-        .catch(err => {
-          if (err.statusCode === 404) {
+          return ''
+        })
+        .catch(function (err){
+          if (err.status === 404) {
             // imposter probably hasn't been added in Mountebank as no stubs were setup for the current
             // test
             return null


### PR DESCRIPTION
## WHAT
- Replaced request library usage in tests with Axios. This is to eventually remove the request library dependency which is not maintained anymore