### PR TITLE
PP-11167 Handle card number in payment link reference error

### DIFF
--- a/app/clients/base/wrapper.js
+++ b/app/clients/base/wrapper.js
@@ -43,6 +43,9 @@ module.exports = function (method, verb) {
         if (errors && errors.constructor.name === 'Array') errors = errors.join(', ')
         const err = new Error(errors || body || 'Unknown error')
         err.errorCode = response.statusCode
+        if (lodash.get(body, 'error_identifier')) {
+          err.error_identifier = lodash.get(body, 'error_identifier')
+        }
         reject(err)
       }
     })

--- a/app/payment-links/confirm/confirm.controller.js
+++ b/app/payment-links/confirm/confirm.controller.js
@@ -133,6 +133,11 @@ async function postPage (req, res, next) {
 
     res.redirect(303, payment.links.next.href)
   } catch (error) {
+    if (error.error_identifier && error.error_identifier === 'CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED') {
+      paymentLinkSession.setError(req, product.externalId, 'fieldValidation.potentialPANInReference')
+      return res.redirect(replaceParamsInPath(paths.paymentLinks.reference, product.externalId))
+    }
+
     if (error.errorCode === 403) {
       return next(new AccountCannotTakePaymentsError('Forbidden response returned by Public API when creating payment'))
     }

--- a/app/payment-links/reference/reference.controller.js
+++ b/app/payment-links/reference/reference.controller.js
@@ -55,6 +55,14 @@ function getPage (req, res, next) {
 
   const sessionReferenceNumber = paymentLinkSession.getReference(req, product.externalId)
 
+  if (paymentLinkSession.getError(req, product.externalId)) {
+    const errors = {}
+    const errorMessage = res.locals.__p(paymentLinkSession.getError(req, product.externalId))
+    errors[PAYMENT_REFERENCE] = capitaliseFirstLetter(errorMessage)
+    paymentLinkSession.setError(req, product.externalId, '')
+    data.errors = errors
+  }
+
   data.backLinkHref = getBackLinkUrl(change, product)
 
   if (sessionReferenceNumber) {

--- a/app/payment-links/utils/payment-link-session.js
+++ b/app/payment-links/utils/payment-link-session.js
@@ -7,6 +7,7 @@ const REFERENCE_KEY = 'reference'
 const AMOUNT_KEY = 'amount'
 const REFERENCE_PROVIDED_BY_QUERY_PARAMS_KEY = 'referenceProvidedByQueryParams'
 const AMOUNT_PROVIDED_BY_QUERY_PARAMS_KEY = 'amountProvidedByQueryParams'
+const ERROR_KEY = 'error'
 
 function cookieIndex (key, productExternalId) {
   return `${getSessionCookieName()}.${productExternalId}.${key}`
@@ -42,6 +43,14 @@ function getAmountProvidedByQueryParams (req, productExternalId) {
   return lodash.get(req, cookieIndex(AMOUNT_PROVIDED_BY_QUERY_PARAMS_KEY, productExternalId), false)
 }
 
+function getError (req, productExternalId) {
+  return lodash.get(req, cookieIndex(ERROR_KEY, productExternalId))
+}
+
+function setError (req, productExternalId, error) {
+  lodash.set(req, cookieIndex(ERROR_KEY, productExternalId), error)
+}
+
 function deletePaymentLinkSession (req, productExternalId) {
   lodash.unset(req, `${getSessionCookieName()}.${productExternalId}`)
 }
@@ -53,5 +62,7 @@ module.exports = {
   setAmount,
   getReferenceProvidedByQueryParams,
   getAmountProvidedByQueryParams,
-  deletePaymentLinkSession
+  deletePaymentLinkSession,
+  getError,
+  setError
 }

--- a/app/payment-links/utils/payment-link-session.test.js
+++ b/app/payment-links/utils/payment-link-session.test.js
@@ -5,6 +5,7 @@ const paymentLinkSession = require('./payment-link-session')
 const productExternalId = 'a-product-external-id'
 const reference = 'REF123'
 const amount = 1234
+const error = 'some-error'
 
 describe('Payment link session utilities', () => {
   describe('Get reference', () => {
@@ -108,6 +109,35 @@ describe('Payment link session utilities', () => {
 
       const sessionAmount = paymentLinkSession.getAmount(req, productExternalId)
       expect(sessionAmount).to.equal(amount)
+    })
+  })
+
+  describe('Get error', () => {
+    it('should return undefined when there is no session', () => {
+      const req = {}
+      const sessionAmount = paymentLinkSession.getError(req, productExternalId)
+      expect(sessionAmount).to.equal(undefined)
+    })
+
+    it('should return error from session', () => {
+      const req = {
+        session: {
+          'a-product-external-id': {
+            error
+          }
+        }
+      }
+      const sessionRef = paymentLinkSession.getError(req, productExternalId)
+      expect(sessionRef).to.equal('some-error')
+    })
+  })
+
+  describe('Set error', () => {
+    it('should set the error when there is no payment link session', () => {
+      const req = {}
+      paymentLinkSession.setError(req, productExternalId, error)
+
+      expect(paymentLinkSession.getError(req, productExternalId)).to.equal(error)
     })
   })
 

--- a/test/cypress/stubs/payment-stubs.js
+++ b/test/cypress/stubs/payment-stubs.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const { stubBuilder } = require('./stub-builder')
+
+function createPaymentErrorStub (opts) {
+  const path = `/v1/api/products/${opts.product_external_id}/payments`
+  return stubBuilder('POST', path, 400, {
+    response: {
+      errors: [
+        'Downstream system error.'
+      ],
+      error_identifier: 'CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED'
+    }
+  })
+}
+
+module.exports = {
+  createPaymentErrorStub
+}


### PR DESCRIPTION
# WHAT
- Displays reference page with errors if a card number is entered and products returns `CARD_NUMBER_IN_PAYMENT_LINK_REFERENCE_REJECTED` error identifier
- uses existing `potentialPANInReference` error text



<img width="586" alt="image" src="https://github.com/alphagov/pay-products-ui/assets/40598480/a5bdfb7f-ddaf-4996-a448-a83041b9204a">
