### PR TITLE
PP-11138: Dependabot security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
@@ -34,7 +34,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 0
+  open-pull-requests-limit: 5
   labels:
   - dependencies
   - govuk-pay


### PR DESCRIPTION
See RFC: https://github.com/alphagov/pay-architecture/discussions/97

Sets NPM and Github Actions package ecosystems to security updates only.