### PR TITLE
BAU: Fix Dependabot Docker ignore, npm security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 5
+  open-pull-requests-limit: 0
   labels:
   - dependencies
   - govuk-pay
@@ -28,7 +28,7 @@ updates:
   ignore:
   - dependency-name: node
     versions:
-    - ">= 18"
+    - "> 18"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
We aren't currently getting the latest minor/patch versions of v18 Node base images, including alpine base updates

Also brings the npm depedency strategy in line with other Node apps, by setting to security updates only. This will help make sure security updates can be quickly identified.