### PR TITLE
BAU: Ignore Node updates for v19 and above

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,7 +28,7 @@ updates:
   ignore:
   - dependency-name: node
     versions:
-    - "> 18"
+    - ">= 19"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
I got the value slightly wrong in the previous PR: https://github.com/alphagov/pay-products-ui/pull/2618.

We still want to receive updates for minor versions of Node v18.