### PR TITLE
PP-11288 improve validation payment links v2

### DIFF
--- a/app/payment-links/amount/amount.controller.test.js
+++ b/app/payment-links/amount/amount.controller.test.js
@@ -234,6 +234,32 @@ describe('Amount Page Controller', () => {
       sinon.assert.calledWith(res.locals.__p, 'paymentLinks.fieldValidation.enterAnAmountInPounds')
     })
 
+    it('when a zero value amount is entered, it should display an error message and the back link correctly', () => {
+      req = {
+        correlationId: '123',
+        product,
+        body: {
+          'payment-amount': '0.00'
+        }
+      }
+
+      res = {
+        redirect: sinon.spy(),
+        locals: {
+          __p: sinon.spy()
+        }
+      }
+
+      controller.postPage(req, res)
+
+      sinon.assert.calledWith(responseSpy, req, res, 'amount/amount')
+
+      const pageData = mockResponses.response.args[0][3]
+      expect(pageData.backLinkHref).to.equal('/pay/an-external-id/reference')
+
+      sinon.assert.calledWith(res.locals.__p, 'paymentLinks.fieldValidation.enterANonZeroAmountInPounds')
+    })
+
     it('when an invalid amount is entered and the change query parameter is present, it should display an error' +
       'message and set the back link to the CONFIRM page', () => {
       req = {

--- a/app/payment/pre-payment.controller.js
+++ b/app/payment/pre-payment.controller.js
@@ -48,7 +48,7 @@ module.exports = (req, res) => {
         paymentLinkSession.setReference(req, product.externalId, reference, true)
       }
       if (!product.price && amount) {
-        if (!isPositiveNumber(amount) || isAboveMaxAmountInPence(parseInt(amount))) {
+        if (!isPositiveNumber(amount) || isAboveMaxAmountInPence(parseInt(amount)) || (parseInt(amount) === 0)) {
           throw new InvalidPrefilledAmountError(`Invalid amount: ${amount}`)
         }
         paymentLinkSession.setAmount(req, product.externalId, amount, true)

--- a/app/utils/validation/form-validations.js
+++ b/app/utils/validation/form-validations.js
@@ -8,6 +8,7 @@ const MAX_REFERENCE_LENGTH = 255
 
 const validationMessageKeys = {
   enterAnAmountInPounds: 'paymentLinks.fieldValidation.enterAnAmountInPounds',
+  enterANonZeroAmountInPounds: 'paymentLinks.fieldValidation.enterANonZeroAmountInPounds',
   enterAnAmountInTheCorrectFormat: 'paymentLinks.fieldValidation.enterAnAmountInTheCorrectFormat',
   enterAnAmountUnderMaxAmount: 'paymentLinks.fieldValidation.enterAnAmountUnderMaxAmount',
   enterAReference: 'paymentLinks.fieldValidation.enterAReference',
@@ -35,6 +36,13 @@ function isEmptyAmount (value) {
   } else {
     return false
   }
+}
+
+function isZeroAmount (value) {
+  if (!isNotCurrency(value) && parseInt(value.trim()) === 0) {
+    return validationMessageKeys.enterANonZeroAmountInPounds
+  }
+  return false
 }
 
 function isNotCurrency (value) {
@@ -90,6 +98,11 @@ function validateAmount (amount) {
   const isAboveMaxAmountErrorMessageKey = isAboveMaxAmount(amount)
   if (isAboveMaxAmountErrorMessageKey) {
     return notValidReturnObject(isAboveMaxAmountErrorMessageKey)
+  }
+
+  const isZeroAmountErrorMessageKey = isZeroAmount(amount)
+  if (isZeroAmountErrorMessageKey) {
+    return notValidReturnObject(isZeroAmountErrorMessageKey)
   }
 
   return validReturnObject

--- a/app/utils/validation/form-validations.js
+++ b/app/utils/validation/form-validations.js
@@ -39,7 +39,7 @@ function isEmptyAmount (value) {
 }
 
 function isZeroAmount (value) {
-  if (!isNotCurrency(value) && (['0', '0.0', '0.00'].indexOf(value) > -1)) {
+  if (!isNotCurrency(value) && ((Number(value) * 100) === 0)) {
     return validationMessageKeys.enterANonZeroAmountInPounds
   }
   return false

--- a/app/utils/validation/form-validations.js
+++ b/app/utils/validation/form-validations.js
@@ -39,7 +39,7 @@ function isEmptyAmount (value) {
 }
 
 function isZeroAmount (value) {
-  if (!isNotCurrency(value) && parseInt(value.trim()) === 0) {
+  if (!isNotCurrency(value) && (['0', '0.0', '0.00'].indexOf(value) > -1)) {
     return validationMessageKeys.enterANonZeroAmountInPounds
   }
   return false

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -87,6 +87,7 @@
     },
     "fieldValidation": {
       "enterAnAmountInPounds": "Cofnodwch swm o arian i’w dalu",
+      "enterANonZeroAmountInPounds": "Rhaid i'r swm fod yn £0.01 neu fwy",
       "enterAnAmountInTheCorrectFormat": "Cofnodwch swm mewn punnoedd a cheiniogau gan ddefnyddio digidau a phwynt degol, fel 123.45 neu 156.00",
       "enterAnAmountUnderMaxAmount": "Cofnodwch swm sy’n £100,000 neu lai",
       "enterAReference": "Mae’n rhaid i chi gofnodi’ch %s",

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,104 +1,105 @@
 {
-  "adhoc": {
-    "title": "Make a payment to ",
-    "paymentAmount": "Payment amount",
-    "inCurrency": "in £",
-    "currencyInput": {
-      "ariaLabel": "Enter amount in pounds",
-      "confirmationLabel": "Amount to pay:"
-    }
-  },
-  "buttons": {
-    "proceed": "Proceed to payment",
-    "continue": "Continue",
-    "confirmAndContinue": "Confirm and continue",
-    "edit": "Edit"
-  },
-  "error": {
-    "title": "An error occurred:",
-    "default": "There’s a problem with the payments platform. Please try again later",
-    "internal": "Sorry, we’re unable to process your request. Try again later.",
-    "contactService": "Please contact the service you are trying to make a payment to."
-  },
-  "paymentLinkError": {
-    "title": "An error occurred:",
-    "invalidReference": "Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
-    "invalidAmount": "Enter an amount in pence. For example ’2000’.",
-    "linkProblem": "There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to."
-  },
-  "404Page": {
-    "title": "Page not found",
-    "bodyTextParagraph1": "If you typed the web address, check it is correct.",
-    "bodyTextParagraph2": "If you pasted the web address, check that you copied the entire address.",
-    "bodyTextParagraph3": "If the web address is correct or you selected a link or button, please contact the service you are trying to make a payment to."
-  },
-  "confirmation": {
-    "title": "Your payment was successful",
-    "titleMoto": "The payment was successful",
-    "referenceNumber": "Your payment reference number is",
-    "referenceNumberMoto": "The payment reference number is",
-    "next": {
-      "title": "What happens next",
-      "body": "We have sent you a confirmation email.",
-      "bodyMoto": "We have sent the user a confirmation email."
-    },
-    "paymentSummary": {
-      "title": "Payment summary",
-      "description": "Payment for:",
-      "amount": "Total amount:"
-    },
-    "goToDashboard": "Go to the dashboard"
-  },
-  "failed": {
-    "title": "Your payment has been declined",
-    "body": "Contact your bank for more details. No money has been taken from your account.",
-    "tryAgain": "Go back to try the payment again"
-  },
-  "fieldValidation": {
-    "summary": "The following fields are missing or contain errors",
-    "generic": "Enter a valid %s",
-    "required": "This field can’t be blank",
-    "currency": "Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”",
-    "isAboveMaxAmount": "Choose an amount under £%s",
-    "isGreaterThanMaxLengthChars": "Text is too long. It can be no more than 50 characters.",
-    "invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]",
-    "potentialPANInReferenceTitle": "Are you sure this is a reference number?",
-    "potentialPANInReference": "Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number."
-  },
-  "paymentLinks": {
-    "common": {
-      "back": "Back",
-      "thereIsAProblem": "There is a problem"
-    },
-    "start": {
-      "title": "Make a payment"
-    },
-    "reference": {
-      "pleaseEnterYour": "Enter your"
-    },
-    "amount": {
-      "enterAmountToPay": "Enter amount to pay"
-    },
-    "confirm": {
-      "checkYourDetails": "Check your details",
-      "totalToPay": "Total to pay",
-      "change": "Change",
-      "continueToPayment": "Continue to payment"
-    },
-    "fieldValidation": {
-      "enterAnAmountInPounds": "Enter an amount of money to pay",
-      "enterAnAmountInTheCorrectFormat": "Enter an amount in pounds and pence using digits and a decimal point, like 123.45 or 156.00",
-      "enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or less",
-      "enterAReference": "You must enter your %s",
-      "referenceTooLong": "%s must be 255 characters or fewer",
-      "referenceCantUseInvalidChars": "%s must not include any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
-      "youMustSelectIAmNotARobot": "You must select 'I’m not a robot' before proceeding to payment."
-    },
-    "error": {
-      "internal": {
-        "title": "Sorry, there is a problem with the service",
-        "message": "Try again later or contact the service you are trying to make a payment to."
-      }
-    }
-  }
+	"adhoc": {
+		"title": "Make a payment to ",
+		"paymentAmount": "Payment amount",
+		"inCurrency": "in £",
+		"currencyInput": {
+			"ariaLabel": "Enter amount in pounds",
+			"confirmationLabel": "Amount to pay:"
+		}
+	},
+	"buttons": {
+		"proceed": "Proceed to payment",
+		"continue": "Continue",
+		"confirmAndContinue": "Confirm and continue",
+		"edit": "Edit"
+	},
+	"error": {
+		"title": "An error occurred:",
+		"default": "There’s a problem with the payments platform. Please try again later",
+		"internal": "Sorry, we’re unable to process your request. Try again later.",
+		"contactService": "Please contact the service you are trying to make a payment to."
+	},
+	"paymentLinkError": {
+		"title": "An error occurred:",
+		"invalidReference": "Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
+		"invalidAmount": "Enter an amount in pence. For example ’2000’.",
+		"linkProblem": "There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to."
+	},
+	"404Page": {
+		"title": "Page not found",
+		"bodyTextParagraph1": "If you typed the web address, check it is correct.",
+		"bodyTextParagraph2": "If you pasted the web address, check that you copied the entire address.",
+		"bodyTextParagraph3": "If the web address is correct or you selected a link or button, please contact the service you are trying to make a payment to."
+	},
+	"confirmation": {
+		"title": "Your payment was successful",
+		"titleMoto": "The payment was successful",
+		"referenceNumber": "Your payment reference number is",
+		"referenceNumberMoto": "The payment reference number is",
+		"next": {
+			"title": "What happens next",
+			"body": "We have sent you a confirmation email.",
+			"bodyMoto": "We have sent the user a confirmation email."
+		},
+		"paymentSummary": {
+			"title": "Payment summary",
+			"description": "Payment for:",
+			"amount": "Total amount:"
+		},
+		"goToDashboard": "Go to the dashboard"
+	},
+	"failed": {
+		"title": "Your payment has been declined",
+		"body": "Contact your bank for more details. No money has been taken from your account.",
+		"tryAgain": "Go back to try the payment again"
+	},
+	"fieldValidation": {
+		"summary": "The following fields are missing or contain errors",
+		"generic": "Enter a valid %s",
+		"required": "This field can’t be blank",
+		"currency": "Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”",
+		"isAboveMaxAmount": "Choose an amount under £%s",
+		"isGreaterThanMaxLengthChars": "Text is too long. It can be no more than 50 characters.",
+		"invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]",
+		"potentialPANInReferenceTitle": "Are you sure this is a reference number?",
+		"potentialPANInReference": "Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number."
+	},
+	"paymentLinks": {
+		"common": {
+			"back": "Back",
+			"thereIsAProblem": "There is a problem"
+		},
+		"start": {
+			"title": "Make a payment"
+		},
+		"reference": {
+			"pleaseEnterYour": "Enter your"
+		},
+		"amount": {
+			"enterAmountToPay": "Enter amount to pay"
+		},
+		"confirm": {
+			"checkYourDetails": "Check your details",
+			"totalToPay": "Total to pay",
+			"change": "Change",
+			"continueToPayment": "Continue to payment"
+		},
+		"fieldValidation": {
+			"enterAnAmountInPounds": "Enter an amount of money to pay",
+			"enterANonZeroAmountInPounds": "Amount must be £0.01 or more",
+			"enterAnAmountInTheCorrectFormat": "Enter an amount in pounds and pence using digits and a decimal point, like 123.45 or 156.00",
+			"enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or less",
+			"enterAReference": "You must enter your %s",
+			"referenceTooLong": "%s must be 255 characters or fewer",
+			"referenceCantUseInvalidChars": "%s must not include any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
+			"youMustSelectIAmNotARobot": "You must select 'I’m not a robot' before proceeding to payment."
+		},
+		"error": {
+			"internal": {
+				"title": "Sorry, there is a problem with the service",
+				"message": "Try again later or contact the service you are trying to make a payment to."
+			}
+		}
+	}
 }

--- a/test/cypress/integration/payment-links/amount.cy.js
+++ b/test/cypress/integration/payment-links/amount.cy.js
@@ -47,6 +47,18 @@ describe('Amount page', () => {
       cy.get('[data-cy=error-message]').should('contain', 'Enter an amount in pounds and pence using digits and a decimal point, like 123.45 or 156.00')
     })
 
+    it('when the amount is £0.00, should display an error', () => {
+      cy.visit('/pay/a-product-id/amount')
+      cy.get('[data-cy=input]').type('0.00', { delay: 0 })
+      cy.get('[data-cy=button]').click()
+
+      cy.get('[data-cy=error-summary] a')
+        .should('contain', 'Amount must be £0.01 or more')
+        .should('have.attr', 'href', '#payment-amount')
+
+      cy.get('[data-cy=error-message]').should('contain', 'Amount must be £0.01 or more')
+    })
+
     it('when a valid amount is entered, should then go to the `confirm` page', () => {
       cy.visit('/pay/a-product-id/amount')
       cy.get('[data-cy=input]')


### PR DESCRIPTION
### Improve validation for amount on Prefilled & Non-Prefilled payment links
For prefilled payment links, the service can set a reference and also an amount for payment links when sending the link to users.
The change involves the following:

When the user has to enter the amount manually for a non-prefilled payment link user journey, an appropriate error page with the agreed error message is displayed, if the amount is £0

Validate the amount added to the prepayment link and display an appropriate error page with the agreed error message, if the amount is £0, bypassing the confirmation page

Some further changes was done in the pay-products API, but that has be approved and released as a non-breaking change.
### What is required to test the functionality change
Knowledge of the prefilled payment link and associated validation rules.