### PR TITLE
PP11788: Products payment creation exception review

### DIFF
--- a/locales/cy.json
+++ b/locales/cy.json
@@ -22,7 +22,7 @@
   },
   "paymentLinkError": {
     "title": "Digwyddodd gwall:",
-    "invalidReference": "Rhif mae’n rhaid i fod yn 255 nod neu lai. Ni allwch ddefnyddio unrhyw rai o’r nodau canlynol < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
+    "invalidReference": "Rhif mae’n rhaid i fod yn 255 nod neu lai. Ni allwch ddefnyddio unrhyw rai o’r nodau canlynol < > ; : ` ( ) \" = | \",\" ~ [ ]",
     "invalidAmount": "Cofnodwch swm mewn ceiniogau. Er enghraifft ’2000’.",
     "linkProblem": "Mae problem gyda’r ddolen sydd wedi cael ei hanfon atoch i’w defnyddio i dalu. Cysylltwch â’r gwasanaeth rydych chi’n ceisio gwneud taliad iddo."
   },
@@ -61,7 +61,7 @@
     "currency": "Dewiswch swm mewn punnoedd a cheiniogau drwy ddefnyddio digidau a phwynt degol. Er enghraifft “10.50”",
     "isAboveMaxAmount": "Dewiswch swm sy’n llai na £%s",
     "isGreaterThanMaxLengthChars": "Mae’r testun yn rhy hir. Ni all fod yn fwy na 50 o nodau.",
-    "invalidCharacters": "Ni allwch ddefnyddio unrhyw rai o’r nodau canlynol < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]",
+    "invalidCharacters": "Ni allwch ddefnyddio unrhyw rai o’r nodau canlynol < > ; : ` ( ) \" = &#124; \",\" ~ [ ]",
     "potentialPANInReferenceTitle": "Ydych chi’n siŵr mae rhif cyfeirnod yw hwn? ",
     "potentialPANInReference": "Gwiriwch eich bod wedi nodi’r rhif yn gywir cyn gwneud y taliad. Peidiwch â nodi’ch rhif cerdyn debyd neu gredyd."
   },
@@ -92,7 +92,7 @@
       "enterAnAmountUnderMaxAmount": "Cofnodwch swm sy’n £100,000 neu lai",
       "enterAReference": "Mae’n rhaid i chi gofnodi’ch %s",
       "referenceTooLong": "Mae’n rhaid i %s fod yn 255 nod neu lai",
-      "referenceCantUseInvalidChars": "Mae’n rhaid i %s beidio â chynnwys unrhyw un o’r nodau canlynol < > ; : ` ( ) \" ’ = | \",\" ~ [ ]",
+      "referenceCantUseInvalidChars": "Mae’n rhaid i %s beidio â chynnwys unrhyw un o’r nodau canlynol < > ; : ` ( ) \" = | \",\" ~ [ ]",
       "youMustSelectIAmNotARobot": "Mae’n rhaid i chi ddewis ’dw i ddim yn robot’ cyn symud ymlaen at dalu"
     },
     "error": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -22,7 +22,7 @@
 	},
 	"paymentLinkError": {
 		"title": "An error occurred:",
-		"invalidReference": "Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
+		"invalidReference": "Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) \" = | \",\" ~ [ ]",
 		"invalidAmount": "Enter an amount in pence. For example ’2000’.",
 		"linkProblem": "There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to."
 	},
@@ -61,7 +61,7 @@
 		"currency": "Choose an amount in pounds and pence using digits and a decimal point. For example “10.50”",
 		"isAboveMaxAmount": "Choose an amount under £%s",
 		"isGreaterThanMaxLengthChars": "Text is too long. It can be no more than 50 characters.",
-		"invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" ' = &#124; \",\" ~ [ ]",
+		"invalidCharacters": "You can’t use any of the following characters < > ; : ` ( ) \" = &#124; \",\" ~ [ ]",
 		"potentialPANInReferenceTitle": "Are you sure this is a reference number?",
 		"potentialPANInReference": "Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number."
 	},
@@ -92,7 +92,7 @@
 			"enterAnAmountUnderMaxAmount": "Enter an amount that is £100,000 or less",
 			"enterAReference": "You must enter your %s",
 			"referenceTooLong": "%s must be 255 characters or fewer",
-			"referenceCantUseInvalidChars": "%s must not include any of the following characters < > ; : ` ( ) \" ' = | \",\" ~ [ ]",
+			"referenceCantUseInvalidChars": "%s must not include any of the following characters < > ; : ` ( ) \" = | \",\" ~ [ ]",
 			"youMustSelectIAmNotARobot": "You must select 'I’m not a robot' before proceeding to payment."
 		},
 		"error": {

--- a/test/cypress/integration/payment-links/details-provided-in-query-params.cy.js
+++ b/test/cypress/integration/payment-links/details-provided-in-query-params.cy.js
@@ -90,7 +90,7 @@ describe('Payment link visited with invalid reference in query params', () => {
   it('should show an error page when the payment link is visited', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}?reference=<>`, { failOnStatusCode: false })
     cy.get('h1').should('have.text', 'An error occurred:')
-    cy.get('[data-cy=error-message]').should('contain.text', 'Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) \" = | \",\" ~ [ ]')
+    cy.get('[data-cy=error-message]').should('contain.text', 'Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) " = | "," ~ [ ]')
     cy.get('[data-cy=error-message]').should('contain.text', 'There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to.')
   })
 })

--- a/test/cypress/integration/payment-links/details-provided-in-query-params.cy.js
+++ b/test/cypress/integration/payment-links/details-provided-in-query-params.cy.js
@@ -90,7 +90,7 @@ describe('Payment link visited with invalid reference in query params', () => {
   it('should show an error page when the payment link is visited', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}?reference=<>`, { failOnStatusCode: false })
     cy.get('h1').should('have.text', 'An error occurred:')
-    cy.get('[data-cy=error-message]').should('contain.text', 'Reference must be 255 characters or fewer. You cannot use any of the following characters')
+    cy.get('[data-cy=error-message]').should('contain.text', 'Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) \" = | \",\" ~ [ ]')
     cy.get('[data-cy=error-message]').should('contain.text', 'There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to.')
   })
 })

--- a/test/cypress/integration/payment-links/reference-and-reference-confirm.cy.js
+++ b/test/cypress/integration/payment-links/reference-and-reference-confirm.cy.js
@@ -6,6 +6,7 @@ const serviceStubs = require('../../stubs/service-stubs')
 const gatewayAccountId = 666
 const productExternalId = 'a-product-id'
 
+const textThatIsInvalid= 'This is a piece of text that contains invalid characters e.g. < > ; : ` ( ) " = | "," ~ [ ]'
 const textThatIs256CharactersLong = 'This is a piece of text that contains exactly 256 characters and this is 1 higher ' +
   'than 255 characters and as such it will fail any validation that checks if the text has a length of 255 ' +
   'characters or fewer because it is exactly 1 character longer than that'
@@ -55,6 +56,20 @@ describe('Reference and reference confirm page', () => {
           .should('have.attr', 'href', '#payment-reference')
 
         cy.get('[data-cy=error-message]').should('contain', 'Invoice number must be 255 characters or fewer')
+      })
+
+      it('when an reference is entered that contains invalid characters, should display an error', () => {
+        cy.visit('/pay/a-product-id/reference')
+        cy.get('[data-cy=input]').type(textThatIsInvalid, { delay: 0 })
+        cy.get('[data-cy=button]').click()
+
+        cy.get('[data-cy=error-summary] h2').should('contain', 'There is a problem')
+
+        cy.get('[data-cy=error-summary] a')
+          .should('contain', 'Invoice number must not include any of the following characters < > ; : ` ( ) " = | "," ~ [ ]')
+          .should('have.attr', 'href', '#payment-reference')
+
+        cy.get('[data-cy=error-message]').should('contain', 'Invoice number must not include any of the following characters < > ; : ` ( ) " = | "," ~ [ ]')
       })
     })
   })


### PR DESCRIPTION
Ensure products-ui & products handle reference length and content validation correctly.

https://payments-platform.atlassian.net/browse/PP-11788

Story review highlighted that apostrophes are not classed as invalid characters in payment link references. Error message for invalid characters  changed to remove apostrophes. 
This is to reflect the change made in `pay-js-commons` to allow apostrophes in pre-filled payment link references
( https://github.com/alphagov/pay-js-commons/pull/1222 )