### PR TITLE
PP-11340 Clear reference field after positive card number check

### DIFF
--- a/app/payment-links/reference/reference.controller.js
+++ b/app/payment-links/reference/reference.controller.js
@@ -50,18 +50,18 @@ function getPage (req, res, next) {
     return next(new NotFoundError('Attempted to access reference page with a product that auto-generates references.'))
   }
 
-  const sessionReferenceNumber = paymentLinkSession.getReference(req, product.externalId)
-
   if (paymentLinkSession.getError(req, product.externalId)) {
     const errors = {}
     const errorMessage = res.locals.__p(paymentLinkSession.getError(req, product.externalId))
     errors[PAYMENT_REFERENCE] = capitaliseFirstLetter(errorMessage)
     paymentLinkSession.setError(req, product.externalId, '')
     data.errors = errors
+    paymentLinkSession.setReference(req, product.externalId, '')
   }
 
   data.backLinkHref = getBackLinkUrl(change, product)
 
+  const sessionReferenceNumber = paymentLinkSession.getReference(req, product.externalId)
   if (sessionReferenceNumber) {
     data.reference = sessionReferenceNumber
   }

--- a/app/payment-links/reference/reference.controller.js
+++ b/app/payment-links/reference/reference.controller.js
@@ -56,7 +56,7 @@ function getPage (req, res, next) {
     errors[PAYMENT_REFERENCE] = capitaliseFirstLetter(errorMessage)
     paymentLinkSession.setError(req, product.externalId, '')
     data.errors = errors
-    paymentLinkSession.setReference(req, product.externalId, '')
+    paymentLinkSession.removeReference(req, product.externalId)
   }
 
   data.backLinkHref = getBackLinkUrl(change, product)

--- a/app/payment-links/reference/reference.controller.test.js
+++ b/app/payment-links/reference/reference.controller.test.js
@@ -15,13 +15,13 @@ const mockResponses = {
   response: responseSpy
 }
 
-const textThatIs255CharactersLong = 'This text contains exactly 255 characters and this is the precise maximum number '
-  + 'allowed for a payment reference and therefore it should pass the validation that checks the text is at most 255 '
-  + 'characters in length and not a single character more than that'
+const textThatIs255CharactersLong = 'This text contains exactly 255 characters and this is the precise maximum number ' +
+  'allowed for a payment reference and therefore it should pass the validation that checks the text is at most 255 ' +
+  'characters in length and not a single character more than that'
 
-const textThatIs256CharactersLong = 'This is a piece of text that contains exactly 256 characters and this is 1 higher '
-  + 'than 255 characters and as such it will fail any validation that checks if the text has a length of 255 '
-  + 'characters or fewer because it is exactly 1 character longer than that'
+const textThatIs256CharactersLong = 'This is a piece of text that contains exactly 256 characters and this is 1 higher ' +
+  'than 255 characters and as such it will fail any validation that checks if the text has a length of 255 ' +
+  'characters or fewer because it is exactly 1 character longer than that'
 
 let req, res
 
@@ -30,6 +30,7 @@ describe('Reference Page Controller', () => {
     getReference: sinon.stub(),
     getAmount: sinon.stub(),
     setReference: sinon.stub(),
+    removeReference: sinon.stub(),
     setError: sinon.stub(),
     getError: sinon.stub()
   }
@@ -123,6 +124,7 @@ describe('Reference Page Controller', () => {
           reference: '4242',
           errors: { 'payment-reference': 'Error message' }
         })
+        sinon.assert.calledWith(mockPaymentLinkSession.removeReference, req, product.externalId)
       })
     })
 

--- a/app/payment-links/utils/payment-link-session.js
+++ b/app/payment-links/utils/payment-link-session.js
@@ -24,6 +24,10 @@ function setReference (req, productExternalId, reference, providedByQueryParams 
   }
 }
 
+function removeReference (req, productExternalId) {
+  lodash.unset(req, cookieIndex(REFERENCE_KEY, productExternalId))
+}
+
 function getAmount (req, productExternalId) {
   return lodash.get(req, cookieIndex(AMOUNT_KEY, productExternalId))
 }
@@ -58,6 +62,7 @@ function deletePaymentLinkSession (req, productExternalId) {
 module.exports = {
   getReference,
   setReference,
+  removeReference,
   getAmount,
   setAmount,
   getReferenceProvidedByQueryParams,

--- a/app/payment-links/utils/payment-link-session.test.js
+++ b/app/payment-links/utils/payment-link-session.test.js
@@ -45,6 +45,21 @@ describe('Payment link session utilities', () => {
       expect(paymentLinkSession.getReferenceProvidedByQueryParams(req, productExternalId)).to.equal(true)
     })
 
+    it('should remove the reference', () => {
+      const req = {
+        session: {
+          'a-product-external-id': {
+            reference: 'REFTOREMOVE'
+          }
+        }
+      }
+      paymentLinkSession.removeReference(req, productExternalId)
+
+      const sessionRef = paymentLinkSession.getReference(req, productExternalId)
+      // eslint-disable-next-line no-unused-expressions
+      expect(sessionRef).to.be.undefined
+    })
+
     it('should override existing reference', () => {
       const req = {
         session: {

--- a/test/cypress/integration/payment-links/confirm.cy.js
+++ b/test/cypress/integration/payment-links/confirm.cy.js
@@ -167,6 +167,7 @@ describe('Confirm page', () => {
         cy.get('[data-cy=error-summary] a')
           .should('contain', 'Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number')
           .should('have.attr', 'href', '#payment-reference')
+        cy.get('[data-cy=input]').should('have.value', '')
         cy.get('[data-cy=error-message]').should('contain', 'Check that you’ve entered the number correctly before making the payment. Do not enter your debit or credit card number')
       })
     })


### PR DESCRIPTION
When the entry in the reference field of a payment link looks like a card number and fails the check and the user is returned to the reference page, the reference field should be empty.

- Remove reference from session cookie if the field tests positive for a card number
- Empty reference field
- Update cypress test