### PR TITLE
PP-12015: Add GHA to check docker sources are manifests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -135,3 +135,5 @@ jobs:
           npm run cypress:server > /dev/null 2>&1 &
           sleep 3
           npm run cypress:test
+  check-docker-base-images-are-manifests:
+    uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master


### PR DESCRIPTION
# WHAT

Use the reusable workflow in pay-ci to ensure all FROM lines in the Dockerfile are pointing to manifest files