### PR TITLE
PP-11978 improve pre-filled payment link error message

### DIFF
--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -13,6 +13,7 @@ const contactServiceErrorMessagePath = 'error.contactService'
 const linkProblem = 'paymentLinkError.linkProblem'
 const invalidReference = 'paymentLinkError.invalidReference'
 const invalidAmount = 'paymentLinkError.invalidAmount'
+const linkTitle = 'paymentLinkError.title'
 
 module.exports = function (err, req, res, next) {
   const errorPayload = {
@@ -50,12 +51,12 @@ module.exports = function (err, req, res, next) {
   if (err instanceof InvalidPrefilledAmountError) {
     logger.info(`InvalidPrefilledAmountError handled: ${err.message}. Rendering error page`)
     res.status(400)
-    return response(req, res, 'error', { message: linkProblem, messagePreamble: invalidAmount })
+    return response(req, res, 'prefilled-link-error', { title: linkTitle, message: invalidAmount, messagePreamble: linkProblem })
   }
   if (err instanceof InvalidPrefilledReferenceError) {
     logger.info(`InvalidPrefilledReferenceError handled: ${err.message}. Rendering error page`)
     res.status(400)
-    return response(req, res, 'error', { message: linkProblem, messagePreamble: invalidReference })
+    return response(req, res, 'prefilled-link-error', { title: linkTitle, message: invalidReference, messagePreamble: linkProblem })
   }
 
   logger.error(`Internal server error`, errorPayload)

--- a/app/middleware/error-handler.test.js
+++ b/app/middleware/error-handler.test.js
@@ -71,7 +71,7 @@ describe('Error handler middleware', () => {
     errorHandler(err, req, res, next)
     sinon.assert.notCalled(next)
     sinon.assert.calledOnceWithExactly(statusSpy, 400)
-    sinon.assert.calledOnceWithExactly(responseSpy, req, res, 'error', { message: 'paymentLinkError.linkProblem', messagePreamble: 'paymentLinkError.invalidAmount' })
+    sinon.assert.calledOnceWithExactly(responseSpy, req, res, 'prefilled-link-error', { title: 'paymentLinkError.title', message: 'paymentLinkError.invalidAmount', messagePreamble: 'paymentLinkError.linkProblem' })
 
     const expectedMessage = 'InvalidPrefilledAmountError handled: test error. Rendering error page'
     sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
@@ -82,7 +82,7 @@ describe('Error handler middleware', () => {
     errorHandler(err, req, res, next)
     sinon.assert.notCalled(next)
     sinon.assert.calledOnceWithExactly(statusSpy, 400)
-    sinon.assert.calledOnceWithExactly(responseSpy, req, res, 'error', { message: 'paymentLinkError.linkProblem', messagePreamble: 'paymentLinkError.invalidReference' })
+    sinon.assert.calledOnceWithExactly(responseSpy, req, res, 'prefilled-link-error', { title: 'paymentLinkError.title', message: 'paymentLinkError.invalidReference', messagePreamble: 'paymentLinkError.linkProblem' })
 
     const expectedMessage = 'InvalidPrefilledReferenceError handled: test error. Rendering error page'
     sinon.assert.calledWith(infoLoggerSpy, expectedMessage)

--- a/app/views/error.njk
+++ b/app/views/error.njk
@@ -5,6 +5,5 @@
 {% block contentBody %}
   <h1 class="govuk-heading-l">{{ __p('error.title') }}</h1>
 
-  {% if messagePreamble %}<div id="errorMsgPreamble" class="govuk-body" data-cy="error-message">{{ __p(messagePreamble) }}</div>{% endif %}
   <div id="errorMsg" class="govuk-body" data-cy="error-message">{{ __p(message) }}</div>
 {% endblock %}

--- a/app/views/prefilled-link-error.njk
+++ b/app/views/prefilled-link-error.njk
@@ -1,0 +1,13 @@
+{% extends "layout.njk" %}
+
+{% block pageTitle %}{{ __p(title) }} - GOV.UK Pay{% endblock %}
+
+{% block contentBody %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">{{ __p(title) }}</h1>
+      <div id="errorMsg" class="govuk-body" data-cy="error-message">{{ __p(messagePreamble) }}</div>
+      <div id="errorMsg" class="govuk-body" data-cy="error-message">{{ __p(message) }}</div> 
+    </div>
+  </div>
+{% endblock %}

--- a/locales/cy.json
+++ b/locales/cy.json
@@ -21,9 +21,9 @@
     "contactService": "Mae problem gyda’r cyfleuster taliadau. Rhowch gynnig arall arni wedyn"
   },
   "paymentLinkError": {
-    "title": "Digwyddodd gwall:",
+    "title": "Mae yna broblem",
     "invalidReference": "Rhif mae’n rhaid i fod yn 255 nod neu lai. Ni allwch ddefnyddio unrhyw rai o’r nodau canlynol < > ; : ` ( ) \" = | \",\" ~ [ ]",
-    "invalidAmount": "Cofnodwch swm mewn ceiniogau. Er enghraifft ’2000’.",
+    "invalidAmount": "Ni all swm y taliad fod yn llai na £0.01 ac ni all fod yn fwy na £100,000 .",
     "linkProblem": "Mae problem gyda’r ddolen sydd wedi cael ei hanfon atoch i’w defnyddio i dalu. Cysylltwch â’r gwasanaeth rydych chi’n ceisio gwneud taliad iddo."
   },
   "404Page": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -21,9 +21,9 @@
 		"contactService": "Please contact the service you are trying to make a payment to."
 	},
 	"paymentLinkError": {
-		"title": "An error occurred:",
+		"title": "There is a problem",
 		"invalidReference": "Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) \" = | \",\" ~ [ ]",
-		"invalidAmount": "Enter an amount in pence. For example ’2000’.",
+		"invalidAmount": "The payment amount cannot be less than £0.01 and it cannot be more than £100,000 .",
 		"linkProblem": "There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to."
 	},
 	"404Page": {

--- a/test/cypress/integration/payment-links/details-provided-in-query-params.cy.js
+++ b/test/cypress/integration/payment-links/details-provided-in-query-params.cy.js
@@ -70,8 +70,7 @@ describe('Payment link visited with invalid amount in query params', () => {
 
   it('should show an error page when the payment link is visited', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}?amount=not-valid`, { failOnStatusCode: false })
-    cy.get('h1').should('have.text', 'An error occurred:')
-    cy.get('[data-cy=error-message]').should('contain.text', 'Enter an amount in pence. For example ’2000’.')
+    cy.get('h1').should('have.text', 'There is a problem')
     cy.get('[data-cy=error-message]').should('contain.text', 'There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to.')
   })
 })
@@ -89,7 +88,7 @@ describe('Payment link visited with invalid reference in query params', () => {
 
   it('should show an error page when the payment link is visited', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}?reference=<>`, { failOnStatusCode: false })
-    cy.get('h1').should('have.text', 'An error occurred:')
+    cy.get('h1').should('have.text', 'There is a problem')
     cy.get('[data-cy=error-message]').should('contain.text', 'Reference must be 255 characters or fewer. You cannot use any of the following characters < > ; : ` ( ) " = | "," ~ [ ]')
     cy.get('[data-cy=error-message]').should('contain.text', 'There is a problem with the link you have been sent to use to pay. Please contact the service you are trying to make a payment to.')
   })


### PR DESCRIPTION
PP-11978  Improve error message associated with validation of amount on pre-filled payment links

Summary of changes:

- Amend page title and page heading for prefilled payment link problems
- Reference new payment link template
- Update associated unit test to reflect changes
- Update Cypress integration test
- Remove logic to test for pre-filledpayment link specific message from common error template
- Add template dedicated for pre-filled payment link problems

Screenshots

The screen shots below can also be found in the [jira ticket PP-11978](https://payments-platform.atlassian.net/browse/PP-11978)

![Screenshot 2024-01-17 at 09 31 55](https://github.com/alphagov/pay-products-ui/assets/145327947/cf985698-ee72-4cf5-8124-dfbfab2fda2b)

![Screenshot 2024-01-17 at 09 32 24](https://github.com/alphagov/pay-products-ui/assets/145327947/3df11417-78df-4eac-bbc0-135508b379c7)
