### PR TITLE
Pp 11978 suppress prepayment link error in sentry

### DIFF
--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -59,6 +59,6 @@ module.exports = function (err, req, res, next) {
     return response(req, res, 'prefilled-link-error', { title: linkTitle, message: invalidReference, messagePreamble: linkProblem })
   }
 
-  logger.error(`Internal server error`, errorPayload)
+  logger.error('Internal server error', errorPayload)
   return response(req, res, '500')
 }

--- a/app/payment/pre-payment.controller.js
+++ b/app/payment/pre-payment.controller.js
@@ -43,13 +43,13 @@ module.exports = (req, res, next) => {
       }
       if (product.reference_enabled && reference) {
         if (!validateReference(reference).valid) {
-          return next ( new InvalidPrefilledReferenceError(`Invalid reference: ${reference}`) )
+          return next(new InvalidPrefilledReferenceError(`Invalid reference: ${reference}`))
         }
         paymentLinkSession.setReference(req, product.externalId, reference, true)
       }
       if (!product.price && amount) {
         if (!isPositiveNumber(amount) || isAboveMaxAmountInPence(parseInt(amount)) || (parseInt(amount) === 0)) {
-          return next ( new InvalidPrefilledAmountError(`Invalid amount: ${amount}`) )
+          return next(new InvalidPrefilledAmountError(`Invalid amount: ${amount}`))
         }
         paymentLinkSession.setAmount(req, product.externalId, amount, true)
       }

--- a/app/payment/pre-payment.controller.js
+++ b/app/payment/pre-payment.controller.js
@@ -27,7 +27,7 @@ function isPositiveNumber (value) {
   return value.match(/^\d+$/)
 }
 
-module.exports = (req, res) => {
+module.exports = (req, res, next) => {
   const product = req.product
   const { reference, amount } = req.query || {}
 
@@ -43,13 +43,13 @@ module.exports = (req, res) => {
       }
       if (product.reference_enabled && reference) {
         if (!validateReference(reference).valid) {
-          throw new InvalidPrefilledReferenceError(`Invalid reference: ${reference}`)
+          return next ( new InvalidPrefilledReferenceError(`Invalid reference: ${reference}`) )
         }
         paymentLinkSession.setReference(req, product.externalId, reference, true)
       }
       if (!product.price && amount) {
         if (!isPositiveNumber(amount) || isAboveMaxAmountInPence(parseInt(amount)) || (parseInt(amount) === 0)) {
-          throw new InvalidPrefilledAmountError(`Invalid amount: ${amount}`)
+          return next ( new InvalidPrefilledAmountError(`Invalid amount: ${amount}`) )
         }
         paymentLinkSession.setAmount(req, product.externalId, amount, true)
       }

--- a/app/payment/pre-payment.controller.test.js
+++ b/app/payment/pre-payment.controller.test.js
@@ -19,12 +19,12 @@ const productExternalId = 'product-external-id'
 const queryParamAmount = '10000000'
 const queryParamReference = 'abcd'
 
-function createProduct(referenceEnabled, fixedPrice) {
+function createProduct (referenceEnabled, fixedPrice) {
   return new Product(productFixtures.validProductResponse({
     type: 'ADHOC',
     external_id: productExternalId,
     reference_enabled: referenceEnabled,
-    price: fixedPrice,
+    price: fixedPrice
   }))
 }
 
@@ -39,8 +39,9 @@ describe('Pre payment controller', () => {
         const product = createProduct(true, 1000)
         const req = { product }
         const res = {}
+        const next = {}
 
-        controller(req, res)
+        controller(req, res, next)
 
         sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/reference` })
       })
@@ -50,8 +51,9 @@ describe('Pre payment controller', () => {
         const product = createProduct(false, null)
         const req = { product }
         const res = {}
+        const next = {}
 
-        controller(req, res)
+        controller(req, res, next)
 
         sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/amount` })
       })
@@ -61,8 +63,9 @@ describe('Pre payment controller', () => {
         const product = createProduct(false, 1000)
         const req = { product }
         const res = {}
+        const next = {}
 
-        controller(req, res)
+        controller(req, res, next)
 
         sinon.assert.calledWith(mockResponse.response, req, res, 'start/start', { continueUrl: `/pay/${productExternalId}/confirm` })
       })
@@ -79,8 +82,9 @@ describe('Pre payment controller', () => {
             }
           }
           const res = {}
+          const next = {}
 
-          controller(req, res)
+          controller(req, res, next)
 
           expect(req).to.have.property('session')
           expect(req.session).to.have.property(product.externalId)
@@ -105,8 +109,9 @@ describe('Pre payment controller', () => {
               }
             }
             const res = {}
+            const next = {}
 
-            controller(req, res)
+            controller(req, res, next)
 
             expect(req).to.have.property('session')
             expect(req.session).to.have.property(product.externalId)
@@ -130,8 +135,9 @@ describe('Pre payment controller', () => {
               }
             }
             const res = {}
+            const next = {}
 
-            controller(req, res)
+            controller(req, res, next)
 
             expect(req).to.have.property('session')
             expect(req.session).to.have.property(product.externalId)
@@ -156,8 +162,9 @@ describe('Pre payment controller', () => {
             }
           }
           const res = {}
+          const next = {}
 
-          controller(req, res)
+          controller(req, res, next)
 
           expect(req).to.have.property('session')
           expect(req.session).to.have.property(product.externalId)

--- a/app/payment/pre-payment.controller.test.js
+++ b/app/payment/pre-payment.controller.test.js
@@ -184,8 +184,14 @@ describe('Pre payment controller', () => {
             }
           }
           const res = {}
+          const next = sinon.spy()
 
-          expect(() => controller(req, res)).to.throw(InvalidPrefilledReferenceError, 'Invalid reference: []<>')
+          controller(req, res, next)
+
+          const expectedError = sinon.match.instanceOf(InvalidPrefilledReferenceError)
+            .and(sinon.match.has('message', 'Invalid reference: []<>'))
+
+          sinon.assert.calledWith(next, expectedError)
 
           expect(req).to.not.have.property('session')
         })
@@ -202,8 +208,9 @@ describe('Pre payment controller', () => {
             }
           }
           const res = {}
+          const next = {}
 
-          controller(req, res)
+          controller(req, res, next)
 
           expect(req).to.have.property('session')
           expect(req.session).to.have.property(product.externalId)
@@ -224,8 +231,14 @@ describe('Pre payment controller', () => {
           }
         }
         const res = {}
+        const next = sinon.spy()
 
-        expect(() => controller(req, res)).to.throw(InvalidPrefilledAmountError, 'Invalid amount: not-valid-amount')
+        controller(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(InvalidPrefilledAmountError)
+          .and(sinon.match.has('message', 'Invalid amount: not-valid-amount'))
+
+        sinon.assert.calledWith(next, expectedError)
 
         expect(req).to.not.have.property('session')
       })
@@ -238,8 +251,14 @@ describe('Pre payment controller', () => {
           }
         }
         const res = {}
+        const next = sinon.spy()
 
-        expect(() => controller(req, res)).to.throw(InvalidPrefilledAmountError, 'Invalid amount: 10000001')
+        controller(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(InvalidPrefilledAmountError)
+          .and(sinon.match.has('message', 'Invalid amount: 10000001'))
+
+        sinon.assert.calledWith(next, expectedError)
 
         expect(req).to.not.have.property('session')
       })
@@ -252,8 +271,14 @@ describe('Pre payment controller', () => {
           }
         }
         const res = {}
+        const next = sinon.spy()
 
-        expect(() => controller(req, res)).to.throw(InvalidPrefilledAmountError, 'Invalid amount: -1000')
+        controller(req, res, next)
+
+        const expectedError = sinon.match.instanceOf(InvalidPrefilledAmountError)
+          .and(sinon.match.has('message', 'Invalid amount: -1000'))
+
+        sinon.assert.calledWith(next, expectedError)
 
         expect(req).to.not.have.property('session')
       })


### PR DESCRIPTION
With @JFSGDS 

- No longer throw exceptions when an invalid pre-filled amount or reference.
- Error are now sent to he error handler using the next function.
- Previously, the errors were logging errors in Sentry and we do not want that.  As these errors are user errors.