### PR TITLE
PP 11978 Remove redundant pre-filled payment link error classes

### DIFF
--- a/app/errors.js
+++ b/app/errors.js
@@ -14,15 +14,7 @@ class NotFoundError extends DomainError {
 class AccountCannotTakePaymentsError extends DomainError {
 }
 
-class InvalidPrefilledAmountError extends DomainError {
-}
-
-class InvalidPrefilledReferenceError extends DomainError {
-}
-
 module.exports = {
   NotFoundError,
-  AccountCannotTakePaymentsError,
-  InvalidPrefilledAmountError,
-  InvalidPrefilledReferenceError
+  AccountCannotTakePaymentsError
 }

--- a/app/middleware/error-handler.js
+++ b/app/middleware/error-handler.js
@@ -2,18 +2,12 @@
 
 const {
   NotFoundError,
-  AccountCannotTakePaymentsError,
-  InvalidPrefilledAmountError,
-  InvalidPrefilledReferenceError
+  AccountCannotTakePaymentsError
 } = require('../errors')
 const { response } = require('../utils/response')
 
 const logger = require('../utils/logger')(__filename)
 const contactServiceErrorMessagePath = 'error.contactService'
-const linkProblem = 'paymentLinkError.linkProblem'
-const invalidReference = 'paymentLinkError.invalidReference'
-const invalidAmount = 'paymentLinkError.invalidAmount'
-const linkTitle = 'paymentLinkError.title'
 
 module.exports = function (err, req, res, next) {
   const errorPayload = {
@@ -47,16 +41,6 @@ module.exports = function (err, req, res, next) {
     logger.info(`AccountCannotTakePaymentsError handled: ${err.message}. Rendering error page`)
     res.status(400)
     return response(req, res, 'error', { message: contactServiceErrorMessagePath })
-  }
-  if (err instanceof InvalidPrefilledAmountError) {
-    logger.info(`InvalidPrefilledAmountError handled: ${err.message}. Rendering error page`)
-    res.status(400)
-    return response(req, res, 'prefilled-link-error', { title: linkTitle, message: invalidAmount, messagePreamble: linkProblem })
-  }
-  if (err instanceof InvalidPrefilledReferenceError) {
-    logger.info(`InvalidPrefilledReferenceError handled: ${err.message}. Rendering error page`)
-    res.status(400)
-    return response(req, res, 'prefilled-link-error', { title: linkTitle, message: invalidReference, messagePreamble: linkProblem })
   }
 
   logger.error('Internal server error', errorPayload)

--- a/app/middleware/error-handler.test.js
+++ b/app/middleware/error-handler.test.js
@@ -4,9 +4,7 @@ const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const {
   NotFoundError,
-  AccountCannotTakePaymentsError,
-  InvalidPrefilledAmountError,
-  InvalidPrefilledReferenceError
+  AccountCannotTakePaymentsError
 } = require('../errors')
 
 const req = {
@@ -63,28 +61,6 @@ describe('Error handler middleware', () => {
     sinon.assert.calledOnceWithExactly(responseSpy, req, res, 'error', { message: 'error.contactService' })
 
     const expectedMessage = 'AccountCannotTakePaymentsError handled: test error. Rendering error page'
-    sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
-  })
-
-  it('should render a 400 page and log message when InvalidPrefilledAmountError handled', () => {
-    const err = new InvalidPrefilledAmountError('test error')
-    errorHandler(err, req, res, next)
-    sinon.assert.notCalled(next)
-    sinon.assert.calledOnceWithExactly(statusSpy, 400)
-    sinon.assert.calledOnceWithExactly(responseSpy, req, res, 'prefilled-link-error', { title: 'paymentLinkError.title', message: 'paymentLinkError.invalidAmount', messagePreamble: 'paymentLinkError.linkProblem' })
-
-    const expectedMessage = 'InvalidPrefilledAmountError handled: test error. Rendering error page'
-    sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
-  })
-
-  it('should render a 400 page and log message when InvalidPrefilledReferenceError handled', () => {
-    const err = new InvalidPrefilledReferenceError('test error')
-    errorHandler(err, req, res, next)
-    sinon.assert.notCalled(next)
-    sinon.assert.calledOnceWithExactly(statusSpy, 400)
-    sinon.assert.calledOnceWithExactly(responseSpy, req, res, 'prefilled-link-error', { title: 'paymentLinkError.title', message: 'paymentLinkError.invalidReference', messagePreamble: 'paymentLinkError.linkProblem' })
-
-    const expectedMessage = 'InvalidPrefilledReferenceError handled: test error. Rendering error page'
     sinon.assert.calledWith(infoLoggerSpy, expectedMessage)
   })
 })

--- a/app/payment/pre-payment.controller.js
+++ b/app/payment/pre-payment.controller.js
@@ -47,15 +47,17 @@ module.exports = (req, res, next) => {
       }
       if (product.reference_enabled && reference) {
         if (!validateReference(reference).valid) {
-          logger.info(`InvalidPrefilledReferenceError handled: Invalid reference: ${reference}. Rendering problem page`)
-          return response(req, res, 'prefilled-link-error', { title: linkTitleMessageKey, message: invalidReferenceMessageKey, messagePreamble: linkProblemMessageKey })
+          logger.info(`Invalid prefilled reference error handled: Invalid reference: ${reference}. Rendering problem page`)
+          res.status(400)
+          return response(req, res, 'prefilled-link-error', { title: linkTitleMessageKey, message: invalidReferenceMessageKey, messagePreamble: linkProblemMessageKey }, 400)
         }
         paymentLinkSession.setReference(req, product.externalId, reference, true)
       }
       if (!product.price && amount) {
         if (!isPositiveNumber(amount) || isAboveMaxAmountInPence(parseInt(amount)) || (parseInt(amount) === 0)) {
-          logger.info(`InvalidPrefilledAmountError handled: Invalid amount: ${amount}. Rendering problem page`)
-          return response(req, res, 'prefilled-link-error', { title: linkTitleMessageKey, message: invalidAmountMessageKey, messagePreamble: linkProblemMessageKey })
+          logger.info(`Invalid prefilled amount error handled: Invalid amount: ${amount}. Rendering problem page`)
+          res.status(400)
+          return response(req, res, 'prefilled-link-error', { title: linkTitleMessageKey, message: invalidAmountMessageKey, messagePreamble: linkProblemMessageKey }, 400)
         }
         paymentLinkSession.setAmount(req, product.externalId, amount, true)
       }

--- a/app/payment/pre-payment.controller.test.js
+++ b/app/payment/pre-payment.controller.test.js
@@ -11,6 +11,8 @@ const mockResponse = {
   response: sinon.spy()
 }
 
+const statusSpy = sinon.spy()
+
 const controller = proxyquire('./pre-payment.controller', {
   '../utils/response': mockResponse
 })
@@ -30,6 +32,7 @@ function createProduct (referenceEnabled, fixedPrice) {
 describe('Pre payment controller', () => {
   beforeEach(() => {
     mockResponse.response.resetHistory()
+    statusSpy.resetHistory()
   })
 
   describe('The product type is ADHOC', () => {
@@ -182,7 +185,9 @@ describe('Pre payment controller', () => {
               reference: '[]<>'
             }
           }
-          const res = {}
+          const res = {
+            status: statusSpy
+          }
 
           controller(req, res)
 
@@ -191,6 +196,7 @@ describe('Pre payment controller', () => {
             message: 'paymentLinkError.invalidReference',
             messagePreamble: 'paymentLinkError.linkProblem'
           })
+          sinon.assert.calledOnceWithExactly(statusSpy, 400)
 
           expect(req).to.not.have.property('session')
         })
@@ -229,7 +235,9 @@ describe('Pre payment controller', () => {
             amount: 'not-valid-amount'
           }
         }
-        const res = {}
+        const res = {
+          status: statusSpy
+        }
 
         controller(req, res)
 
@@ -238,6 +246,7 @@ describe('Pre payment controller', () => {
           message: 'paymentLinkError.invalidAmount',
           messagePreamble: 'paymentLinkError.linkProblem'
         })
+        sinon.assert.calledOnceWithExactly(statusSpy, 400)
 
         expect(req).to.not.have.property('session')
       })
@@ -249,7 +258,9 @@ describe('Pre payment controller', () => {
             amount: '10000001'
           }
         }
-        const res = {}
+        const res = {
+          status: statusSpy
+        }
 
         controller(req, res)
 
@@ -258,6 +269,7 @@ describe('Pre payment controller', () => {
           message: 'paymentLinkError.invalidAmount',
           messagePreamble: 'paymentLinkError.linkProblem'
         })
+        sinon.assert.calledOnceWithExactly(statusSpy, 400)
 
         expect(req).to.not.have.property('session')
       })
@@ -269,7 +281,9 @@ describe('Pre payment controller', () => {
             amount: '-1000'
           }
         }
-        const res = {}
+        const res = {
+          status: statusSpy
+        }
 
         controller(req, res)
 
@@ -278,6 +292,7 @@ describe('Pre payment controller', () => {
           message: 'paymentLinkError.invalidAmount',
           messagePreamble: 'paymentLinkError.linkProblem'
         })
+        sinon.assert.calledOnceWithExactly(statusSpy, 400)
 
         expect(req).to.not.have.property('session')
       })


### PR DESCRIPTION
PP-11978 Prevent pre-filled payment link errors displaying in Sentry.

https://payments-platform.atlassian.net/browse/PP-11978

Summary of changes

- Remove redundant error classes as error page now handled in pre-payment controller.
- Reword log messages for pre-filled payment link errors as error classes no longer available. For example:
`"message":"Invalid prefilled reference error handled: Invalid reference: <>. Rendering problem page"`
`"message":"Invalid prefilled amount error handled: Invalid amount: not-valid. Rendering problem page"`
- Set new error page rendered status to 400.
- Update unit tests to reflect the above.

