### PR TITLE
PP-12064 Remove beautify method so references do not have spaces

### DIFF
--- a/app/payment/payment-complete.controller.test.js
+++ b/app/payment/payment-complete.controller.test.js
@@ -142,8 +142,8 @@ describe('payment complete controller', () => {
       it('should redirect to the payment success page', () => {
         expect($('title').text()).to.include(`Your payment was successful - ${service.service_name.en}`)
         expect($('.govuk-header__content').text()).to.include(product.name)
-        expect($('#payment-reference').text()).to.include('ABCD1234EF')
-        expect($('#payment-amount').text()).to.include('£20.00')
+        expect($('#payment-reference').text()).to.equal('ABCD1234EF')
+        expect($('#payment-amount').text()).to.equal('£20.00')
         expect($('a.dashboard-link').length).to.equal(0)
       })
     })
@@ -186,8 +186,8 @@ describe('payment complete controller', () => {
       it('should redirect to the payment success page', () => {
         expect($('title').text()).to.include(`Roedd eich taliad yn llwyddiannus - ${service.service_name.cy}`)
         expect($('.govuk-header__content').text()).to.include(product.name)
-        expect($('#payment-reference').text()).to.include('ABCD1234EF')
-        expect($('#payment-amount').text()).to.include('£20.00')
+        expect($('#payment-reference').text()).to.equal('ABCD1234EF')
+        expect($('#payment-amount').text()).to.equal('£20.00')
         expect($('a.dashboard-link').length).to.equal(0)
       })
     })
@@ -261,8 +261,8 @@ describe('payment complete controller', () => {
       it('should redirect to the payment success page', () => {
         expect($('title').text()).to.include(`The payment was successful - ${service.service_name.en}`)
         expect($('.govuk-header__content').text()).to.include(service.service_name.en)
-        expect($('#payment-reference').text()).to.include('ABCD1234EF')
-        expect($('#payment-amount').text()).to.include('£20.00')
+        expect($('#payment-reference').text()).to.equal('ABCD1234EF')
+        expect($('#payment-amount').text()).to.equal('£20.00')
         expect($('a.dashboard-link').text()).to.include('Go to the dashboard')
         expect($('a.dashboard-link').attr('href')).to.equal(SELFSERVICE_DASHBOARD_URL)
       })

--- a/app/payment/payment-complete.controller.test.js
+++ b/app/payment/payment-complete.controller.test.js
@@ -142,7 +142,7 @@ describe('payment complete controller', () => {
       it('should redirect to the payment success page', () => {
         expect($('title').text()).to.include(`Your payment was successful - ${service.service_name.en}`)
         expect($('.govuk-header__content').text()).to.include(product.name)
-        expect($('#payment-reference').text()).to.include('ABC D123 4EF')
+        expect($('#payment-reference').text()).to.include('ABCD1234EF')
         expect($('#payment-amount').text()).to.include('£20.00')
         expect($('a.dashboard-link').length).to.equal(0)
       })
@@ -186,7 +186,7 @@ describe('payment complete controller', () => {
       it('should redirect to the payment success page', () => {
         expect($('title').text()).to.include(`Roedd eich taliad yn llwyddiannus - ${service.service_name.cy}`)
         expect($('.govuk-header__content').text()).to.include(product.name)
-        expect($('#payment-reference').text()).to.include('ABC D123 4EF')
+        expect($('#payment-reference').text()).to.include('ABCD1234EF')
         expect($('#payment-amount').text()).to.include('£20.00')
         expect($('a.dashboard-link').length).to.equal(0)
       })
@@ -261,7 +261,7 @@ describe('payment complete controller', () => {
       it('should redirect to the payment success page', () => {
         expect($('title').text()).to.include(`The payment was successful - ${service.service_name.en}`)
         expect($('.govuk-header__content').text()).to.include(service.service_name.en)
-        expect($('#payment-reference').text()).to.include('ABC D123 4EF')
+        expect($('#payment-reference').text()).to.include('ABCD1234EF')
         expect($('#payment-amount').text()).to.include('£20.00')
         expect($('a.dashboard-link').text()).to.include('Go to the dashboard')
         expect($('a.dashboard-link').attr('href')).to.equal(SELFSERVICE_DASHBOARD_URL)

--- a/app/payment/payment-status.controller.js
+++ b/app/payment/payment-status.controller.js
@@ -12,19 +12,14 @@ function asGBP (amountInPence) {
   return currencyFormatter.format((amountInPence / 100).toFixed(2), { code: 'GBP' })
 }
 
-function beautify (reference) {
-  return reference.slice(0, 3) + ' ' + reference.slice(3, 7) + ' ' + reference.slice(7)
-}
-
 module.exports = (req, res) => {
   const product = req.product
   const payment = req.payment
   const data = {}
 
   if (payment.govukStatus.toLowerCase() === 'success') {
-    const reference = product.reference_enabled ? payment.referenceNumber : beautify(payment.referenceNumber)
     data.payment = {
-      reference: reference,
+      reference: payment.referenceNumber,
       amount: asGBP(payment.amount)
     }
     if (product.type === 'AGENT_INITIATED_MOTO') {


### PR DESCRIPTION
## What
Removing unnecessary spaces from the payment reference number.

## Why
It is impacting users and is also inconsistent with the usage of references in other places (email, admin tool). Users were copying the reference with spaces. However, service teams won’t be able to find transactions if searching by the same (reference with spaces) as we don’t store spaces in the database or anywhere.
Before:
![Screenshot 2024-02-01 at 14 32 20](https://github.com/alphagov/pay-products-ui/assets/92534363/b4dfa80e-5787-4b65-98bd-9db16052a820)
After:
![Screenshot 2024-02-02 at 15 51 41](https://github.com/alphagov/pay-products-ui/assets/92534363/ddbb0033-e9d9-413c-a9c4-3e449d3384d4)
