### PR TITLE
PP-12468 Bump pay-js-commons update base client import

### DIFF
--- a/app/clients/adminusers/adminusers.client.js
+++ b/app/clients/adminusers/adminusers.client.js
@@ -1,7 +1,7 @@
 'use strict'
 
 // Local dependencies
-const { Client } = require('@govuk-pay/pay-js-commons/lib/utils/axios-base-client/axios-base-client')
+const { HttpsBaseClient } = require('@govuk-pay/pay-js-commons')
 const { configureClient } = require('../base/config')
 const Service = require('../../models/Service.class')
 const { ADMINUSERS_URL } = require('../../../config')
@@ -11,7 +11,7 @@ const SERVICE_NAME = 'adminusers'
 const baseUrl = `${ADMINUSERS_URL}/v1/api`
 
 async function getServiceByGatewayAccountId (gatewayAccountId, correlationId) {
-  this.client = new Client(SERVICE_NAME)
+  this.client = new HttpsBaseClient(SERVICE_NAME)
   const url = `${baseUrl}/services?gatewayAccountId=${gatewayAccountId}`
   configureClient(this.client, url)
   const response = await this.client.get(url, 'find a service by it\'s external id')

--- a/app/clients/base/config.test.js
+++ b/app/clients/base/config.test.js
@@ -4,7 +4,7 @@ const nock = require('nock')
 const sinon = require('sinon')
 const proxyquire = require('proxyquire')
 const { expect } = require('chai')
-const { Client } = require('@govuk-pay/pay-js-commons/lib/utils/axios-base-client/axios-base-client')
+const { HttpsBaseClient } = require('@govuk-pay/pay-js-commons')
 
 const baseUrl = 'http://localhost:8000'
 const app = 'an-app'
@@ -32,7 +32,7 @@ describe('Client config', () => {
 
   describe('Headers', () => {
     it('should add correlation ID as header when correlation ID exists on request context', async () => {
-      const client = new Client(app)
+      const client = new HttpsBaseClient(app)
       const config = getConfigWithMocks('abc123')
 
       config.configureClient(client, baseUrl)
@@ -48,7 +48,7 @@ describe('Client config', () => {
     })
 
     it('should not add correlation ID as header when correlation ID does not exist on request context', async () => {
-      const client = new Client(app)
+      const client = new HttpsBaseClient(app)
       const config = getConfigWithMocks()
       config.configureClient(client, baseUrl)
 
@@ -64,7 +64,7 @@ describe('Client config', () => {
 
   describe('Logging', () => {
     it('should log request start', async () => {
-      const client = new Client(app)
+      const client = new HttpsBaseClient(app)
       const config = getConfigWithMocks('abc123')
       config.configureClient(client, baseUrl)
 

--- a/app/clients/products/products.client.js
+++ b/app/clients/products/products.client.js
@@ -3,7 +3,7 @@
 // Local Dependencies
 const Product = require('../../models/Product.class')
 const Payment = require('../../models/Payment.class')
-const { Client } = require('@govuk-pay/pay-js-commons/lib/utils/axios-base-client/axios-base-client')
+const { HttpsBaseClient } = require('@govuk-pay/pay-js-commons')
 const { configureClient } = require('../base/config')
 const { PRODUCTS_URL } = require('../../../config')
 
@@ -31,7 +31,7 @@ module.exports = {
  * @returns {Promise<Product>}
  */
 async function getProductByExternalId (externalProductId) {
-  this.client = new Client(SERVICE_NAME)
+  this.client = new HttpsBaseClient(SERVICE_NAME)
   const url = `${baseUrl}/products/${externalProductId}`
   configureClient(this.client, url)
   const response = await this.client.get(url, 'find a product by it\'s external id')
@@ -44,11 +44,11 @@ async function getProductByExternalId (externalProductId) {
  * @returns {Promise<Product>}
  */
 async function getProductByPath (serviceNamePath, productNamePath) {
-    this.client = new Client(SERVICE_NAME)
-    const url = `${baseUrl}/products?serviceNamePath=${serviceNamePath}&productNamePath=${productNamePath}`
-    configureClient(this.client, url)
-    const response = await this.client.get(url, 'find a product by it\'s product path')
-    return new Product(response.data)
+  this.client = new HttpsBaseClient(SERVICE_NAME)
+  const url = `${baseUrl}/products?serviceNamePath=${serviceNamePath}&productNamePath=${productNamePath}`
+  configureClient(this.client, url)
+  const response = await this.client.get(url, 'find a product by it\'s product path')
+  return new Product(response.data)
 }
 
 // PAYMENT
@@ -71,7 +71,7 @@ async function createPayment (productExternalId, price, referenceNumber) {
   if (referenceNumber) {
     createPaymentRequest.body.reference_number = referenceNumber
   }
-  this.client = new Client(SERVICE_NAME)
+  this.client = new HttpsBaseClient(SERVICE_NAME)
   const url = `${baseUrl}/products/${productExternalId}/payments`
   configureClient(this.client, url)
   const response = await this.client.post(url, createPaymentRequest.body, 'create a payment for a product')
@@ -83,7 +83,7 @@ async function createPayment (productExternalId, price, referenceNumber) {
  * @returns Promise<Payment>
  */
 async function getPaymentByPaymentExternalId (paymentExternalId) {
-  this.client = new Client(SERVICE_NAME)
+  this.client = new HttpsBaseClient(SERVICE_NAME)
   const url = `${baseUrl}/payments/${paymentExternalId}`
   configureClient(this.client, url)
   const response = await this.client.get(url, 'find a payment by it\'s external id')
@@ -95,9 +95,9 @@ async function getPaymentByPaymentExternalId (paymentExternalId) {
  * @returns Promise<Array<Payment>>
  */
 async function getPaymentsByProductExternalId (productExternalId) {
-  this.client = new Client(SERVICE_NAME)
+  this.client = new HttpsBaseClient(SERVICE_NAME)
   const url = `${baseUrl}/products/${productExternalId}/payments`
   configureClient(this.client, url)
-  const response = await  this.client.get(url, 'find a payments associated with a particular product')
+  const response = await this.client.get(url, 'find a payments associated with a particular product')
   return response.data.map(payment => new Payment(payment))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "^4.0.16",
+        "@govuk-pay/pay-js-commons": "^5.0.1",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "7.74.0",
         "axios": "^1.6.7",
@@ -44,7 +44,7 @@
         "@snyk/protect": "^1.1235.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.2.0",
         "dotenv": "^16.3.1",
         "eslint": "8.47.x",
@@ -2073,9 +2073,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.16.tgz",
-      "integrity": "sha512-CMXVvNlutG3SNeE3o/pgTML0YlXJ0BHPkojKQiaURhDGwjGVuiSAjP/3Gxvu/5ckA9O2dh4pIHzk3HM3dnzu1g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-5.0.1.tgz",
+      "integrity": "sha512-mBlHANg0G4KtczbEzpf7qLSN2VPldvTsDTNu3RjkzRe4xc4MKa8gQ0xfZvfR3FWnaDidjmNX91VZx8xQpCEy/w==",
       "dependencies": {
         "axios": "^1.6.5",
         "lodash": "4.17.21",
@@ -19622,9 +19622,9 @@
       "dev": true
     },
     "@govuk-pay/pay-js-commons": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-4.0.16.tgz",
-      "integrity": "sha512-CMXVvNlutG3SNeE3o/pgTML0YlXJ0BHPkojKQiaURhDGwjGVuiSAjP/3Gxvu/5ckA9O2dh4pIHzk3HM3dnzu1g==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-5.0.1.tgz",
+      "integrity": "sha512-mBlHANg0G4KtczbEzpf7qLSN2VPldvTsDTNu3RjkzRe4xc4MKa8gQ0xfZvfR3FWnaDidjmNX91VZx8xQpCEy/w==",
       "requires": {
         "axios": "^1.6.5",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "^4.0.16",
+    "@govuk-pay/pay-js-commons": "^5.0.1",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "7.74.0",
     "axios": "^1.6.7",


### PR DESCRIPTION
- Update import of the base client to use the new format in pay-js-commons.
- The client has updated from axios-base-client to https-base-client.
- Update code and all tests.