### PR TITLE
PP-13145: Accept BIND_HOST env var and default to localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ npm run compile && npm test
 
 ## Key runtime environment variables
 
-| Variable                              | Description                               |
-|---------------------------------------|:----------------------------------------- |
+| Variable                              | Description                                                          |
+|---------------------------------------|:-------------------------------------------------------------------- |
 | `ADMINUSERS_URL`                      | 
 | `ANALYTICS_TRACKING_ID`               | 
+| `BIND_HOST`                           | The IP address for the application to bind to. Defaults to 127.0.0.1
 | `COOKIE_MAX_AGE`                      | 
 | `CORRELATION_HEADER_NAME`             | Default `x-request-id`
 | `DISABLE_INTERNAL_HTTPS`              | 

--- a/config/server.js
+++ b/config/server.js
@@ -31,6 +31,7 @@ const replaceParamsInPath = require('../app/utils/replace-params-in-path')
 
 // Global constants
 const JAVASCRIPT_PATH = staticify.getVersionedPath('/js/application.min.js')
+const BIND_HOST = process.env.BIND_HOST || "127.0.0.1"
 const PORT = process.env.PORT || 3000
 const { NODE_ENV } = process.env
 const unconfiguredApp = express()
@@ -139,8 +140,8 @@ function initialiseCookies (app) {
 
 function listen () {
   const app = initialise()
-  app.listen(PORT)
-  logger.info('Listening on port ' + PORT)
+  app.listen(PORT, BIND_HOST)
+  logger.info(`Listening on ${BIND_HOST}:${PORT}`)
 }
 
 /**


### PR DESCRIPTION
Bind to 127.0.0.1 by default instead of 0.0.0.0 and allow override with BIND_HOST env var.

You can see this works, on master:

*  On master run `npm run start:dev`
* Then netstat:
    ```
    $ netstat -anl | grep 3000
    tcp46      0      0  *.3000                                        *.*                                           LISTEN
    ```
* Switch to this branch, then `npm run start:dev`
* Then netstat:
    ```
    $ netstat -anl | grep 3000
    tcp4       0      0  127.0.0.1.3000                                *.*                                           LISTEN
    ```
* Now `BIND_HOST=0.0.0.0 npm run start:dev`
* A final netstat to prove the override works
    ```
    $ netstat -anl | grep 3000
    tcp4       0      0  *.3000                                        *.*                                           LISTEN
    ```

Example of the updated logging:
```
{"@timestamp":"2024-09-06T10:51:30.652Z","@version":1,"container":"products-ui","level":"INFO","logger_name":"/Users/jonathan.harden/gitdevel/github.com/alphagov/pay-products-ui/config/server.js","message":"Listening on 127.0.0.1:3000"}
```