### PR TITLE
BAU roll pay-js-commons to revert previous changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "^6.0.10",
+        "@govuk-pay/pay-js-commons": "^6.0.12",
         "@govuk-pay/pay-js-metrics": "^1.0.6",
         "@sentry/node": "7.74.0",
         "axios": "^1.7.4",
@@ -44,7 +44,7 @@
         "@snyk/protect": "^1.1235.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.8.0",
         "dotenv": "^16.3.1",
         "eslint": "8.47.x",
@@ -2036,9 +2036,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "6.0.10",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.10.tgz",
-      "integrity": "sha512-fCwZ10DOJzSYBZ85LXb58Q3pcnCURSqwQCaGmPUFX1t8PGH4TEOfR4xU3ARb991y+IzUn0H1VvsW4rdCwttalw==",
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-6.0.12.tgz",
+      "integrity": "sha512-iKQf7hv5v8h9HGjzYsTEllo2+AN0eo92hVSSpCyRmxfW3IPYPKOGbrh476B3s+CrZiFt18+q0x0cnZze5IQcUg==",
       "dependencies": {
         "axios": "^1.6.5",
         "lodash": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "^6.0.10",
+    "@govuk-pay/pay-js-commons": "^6.0.12",
     "@govuk-pay/pay-js-metrics": "^1.0.6",
     "@sentry/node": "7.74.0",
     "axios": "^1.7.4",


### PR DESCRIPTION
Changes to pay-js-commons had broken custom branding. Revert changes.