### PR TITLE
Spike - Support markdown in payment link description

### DIFF
--- a/app/payment-links/start/start.njk
+++ b/app/payment-links/start/start.njk
@@ -15,7 +15,7 @@
     <h1 class="govuk-heading-l">{{ product.name }}</h1>
 
     {% if product.description %}
-    <p class="govuk-body" data-cy="product-description">{{ product.description | striptags(true) | escape | nl2br }}</p>
+    <div data-cy="product-description">{{ product.description | striptags(true) | formatMarkdown | safe }}</div>
     {% endif %}
   
     {{ govukButton({

--- a/app/utils/format-markdown.js
+++ b/app/utils/format-markdown.js
@@ -1,0 +1,51 @@
+/**
+ * Credit: https://github.com/ministryofjustice/opg-performance-data/
+ */
+'use strict'
+
+const markdownIt = require('markdown-it')
+
+/**
+ * Rules that can be enabled/disabled for markdown-it can be found here:
+ * https://github.com/markdown-it/markdown-it/blob/0fe7ccb4b7f30236fb05f623be6924961d296d3d/lib/parser_block.mjs
+ * https://github.com/markdown-it/markdown-it/blob/HEAD/lib/parser_inline.mjs
+ */
+const md = markdownIt({
+  html: false,
+  breaks: true
+})
+  .disable(['heading', 'lheading', 'image', 'table', 'code', 'fence', 'blockquote', 'hr', 'html_block', 'reference', 'emphasis', 'backticks', 'strikethrough', 'html_inline', 'autolink', 'entity'])
+
+md.renderer.rules.paragraph_open = function (tokens, idx, options, env, self) {
+  tokens[idx].attrPush(['class', 'govuk-body'])
+  return self.renderToken(tokens, idx, options)
+}
+
+md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+  tokens[idx].attrPush(['class', 'govuk-link'])
+  tokens[idx].attrPush(['target', '_blank'])
+  tokens[idx].attrPush(['rel', 'noreferrer noopener'])
+  return self.renderToken(tokens, idx, options)
+}
+
+md.renderer.rules.link_close = function (tokens, idx, options, env, self) {
+  return '<span class="govuk-visually-hidden">(opens in new tab)</span></a>'
+}
+
+md.renderer.rules.bullet_list_open = function (tokens, idx, options, env, self) {
+  tokens[idx].attrPush(['class', 'govuk-list govuk-list--bullet'])
+  return self.renderToken(tokens, idx, options)
+}
+
+md.renderer.rules.ordered_list_open = function (tokens, idx, options, env, self) {
+  tokens[idx].attrPush(['class', 'govuk-list govuk-list--number'])
+  return self.renderToken(tokens, idx, options)
+}
+
+function formatMarkdown (rawText) {
+  return md.render(rawText)
+}
+
+module.exports = {
+  formatMarkdown
+}

--- a/app/utils/format-markdown.test.js
+++ b/app/utils/format-markdown.test.js
@@ -1,0 +1,165 @@
+const { expect } = require('chai')
+
+const { formatMarkdown } = require('./format-markdown')
+
+describe('Format markdown utilities', () => {
+  describe('format markdown', () => {
+    it('formats paragraphs', () => {
+      const input = 'This is a paragraph\n\nAnd another paragraph\n'
+
+      const expectedHTML = '<p class="govuk-body">This is a paragraph</p>\n' +
+        '<p class="govuk-body">And another paragraph</p>\n'
+
+      expect(formatMarkdown(input)).to.eq(expectedHTML)
+    })
+
+    it('formats links', () => {
+      const input = 'This is a [link](http://www.example.com)'
+      const expectedHtml = '<p class="govuk-body">This is a <a href="http://www.example.com" class="govuk-link" ' +
+        'target="_blank" rel="noreferrer noopener">link<span class="govuk-visually-hidden">(opens in new tab)</span></a></p>\n'
+
+      expect(formatMarkdown(input)).to.eq(expectedHtml)
+    })
+
+    it('formats a bulleted list created with asterisks', () => {
+      const input = 'This is a list:\n\n' +
+        '* something\n' +
+        '* something else'
+
+      const expectedHTML = '<p class="govuk-body">This is a list:</p>\n' +
+        '<ul class="govuk-list govuk-list--bullet">\n<' +
+        'li>something</li>\n<li>something else</li>\n' +
+        '</ul>\n'
+
+      expect(formatMarkdown(input)).to.eq(expectedHTML)
+    })
+
+    it('formats a bulleted list created with dashes', () => {
+      const input = 'This is a list:\n\n' +
+        '- something\n' +
+        '- something else'
+
+      const expectedHTML = '<p class="govuk-body">This is a list:</p>\n' +
+        '<ul class="govuk-list govuk-list--bullet">\n<' +
+        'li>something</li>\n' +
+        '<li>something else</li>\n' +
+        '</ul>\n'
+
+      expect(formatMarkdown(input)).to.eq(expectedHTML)
+    })
+
+    it('formats an ordered list', () => {
+      const input = 'This is a list:\n\n' +
+        '1. something\n' +
+        '1. something else'
+
+      const expectedHTML = '<p class="govuk-body">This is a list:</p>\n' +
+        '<ol class="govuk-list govuk-list--number">\n<' +
+        'li>something</li>\n' +
+        '<li>something else</li>\n' +
+        '</ol>\n'
+
+      expect(formatMarkdown(input)).to.eq(expectedHTML)
+    })
+
+    it('escapes HTML', () => {
+      const input = '<div class="this is an html block">\n' +
+        'blah blah\n' +
+        '</div>'
+
+      expect(formatMarkdown(input)).to.contain('&lt;div')
+    })
+
+    it('does not format headings', () => {
+      const input = '# A heading'
+
+      expect(formatMarkdown(input)).to.not.contain('<h1')
+    })
+
+    it('does not format headings with dash syntax', () => {
+      const input = 'Heading level 1\n==============='
+
+      expect(formatMarkdown(input)).to.not.contain('<h1')
+    })
+
+    it('does not format images', () => {
+      const input = '![An image!](/assets/images/govuk-crest.png "An image")'
+
+      expect(formatMarkdown(input)).to.not.contain('<img')
+    })
+
+    it('does not format tables', () => {
+      const input = '|Heading|\n|---|\n|value|'
+
+      expect(formatMarkdown(input)).to.not.contain('<table')
+    })
+
+    it('does not format code blocks', () => {
+      const input = '    a\n' +
+        '    code\n' +
+        '    block'
+
+      expect(formatMarkdown(input)).to.not.contain('<code')
+    })
+
+    it('does not format code fences', () => {
+      const input = '```\nSome code\n```'
+
+      expect(formatMarkdown(input)).to.not.contain('<code')
+    })
+
+    it('does not format blockquotes', () => {
+      const input = '> A blockquote'
+
+      expect(formatMarkdown(input)).to.not.contain('<blockquote')
+    })
+
+    it('does not format horizontal rules', () => {
+      const input = ' ________\n'
+
+      expect(formatMarkdown(input)).to.not.contain('<hr')
+    })
+
+    it('does not format references', () => {
+      const input = '[1]\n\n[1]: <http://something.example.com/foo/bar>'
+
+      expect(formatMarkdown(input)).to.not.contain('<a')
+    })
+
+    it('does not format bold', () => {
+      const input = '**emphasis**'
+
+      expect(formatMarkdown(input)).to.not.contain('<strong')
+    })
+
+    it('does not format italics', () => {
+      const input = '_italics_'
+
+      expect(formatMarkdown(input)).to.not.contain('<em')
+    })
+
+    it('does not format backticks', () => {
+      const input = 'Some `code`'
+
+      expect(formatMarkdown(input)).to.not.contain('<code')
+    })
+
+    it('does not format strikethrough', () => {
+      const input = '~~strikethrough~~'
+
+      expect(formatMarkdown((input))).to.not.contain('<s')
+    })
+
+    it('does not format autolinks', () => {
+      const input = '<http://www.example.com>'
+
+      expect(formatMarkdown((input))).to.not.contain('<a')
+    })
+
+    it('does not format entities', () => {
+      const input = '&copy;'
+
+      expect(formatMarkdown((input))).to.not.contain('©')
+    })
+  })
+})

--- a/config/server.js
+++ b/config/server.js
@@ -28,6 +28,7 @@ const loggingMiddleware = require('../app/middleware/logging-middleware')
 const { requestContextMiddleware } = require('../app/clients/base/request-context')
 const Sentry = require('../app/utils/sentry.js').initialiseSentry()
 const replaceParamsInPath = require('../app/utils/replace-params-in-path')
+const { formatMarkdown } = require('../app/utils/format-markdown')
 
 // Global constants
 const JAVASCRIPT_PATH = staticify.getVersionedPath('/js/application.min.js')
@@ -106,6 +107,9 @@ function initialiseTemplateEngine (app) {
   // if it's not production we want to re-evaluate the assets on each file change
   nunjucksEnvironment.addGlobal('css_path', staticify.getVersionedPath('/stylesheets/application.min.css'))
   nunjucksEnvironment.addGlobal('js_path', NODE_ENV === 'production' ? JAVASCRIPT_PATH : staticify.getVersionedPath('/js/application.js'))
+
+  // Load custom Nunjucks filters
+  nunjucksEnvironment.addFilter('formatMarkdown', formatMarkdown)
 }
 
 function initialisePublic (app) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "i18n": "^0.15.1",
         "lodash": "4.17.x",
         "luhn-js": "^1.1.2",
+        "markdown-it": "^14.1.0",
         "minimist": "^1.2.8",
         "morgan": "1.10.x",
         "nunjucks": "^3.2.4",
@@ -3055,8 +3056,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.1",
@@ -5707,7 +5707,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -11122,6 +11121,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/markdown-it/node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+    },
     "node_modules/math-interval-parser": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/math-interval-parser/-/math-interval-parser-2.0.1.tgz",
@@ -11244,6 +11272,11 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
       "dev": true
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
@@ -13919,6 +13952,14 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
       "dev": true
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/qs": {
       "version": "6.11.0",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "i18n": "^0.15.1",
     "lodash": "4.17.x",
     "luhn-js": "^1.1.2",
+    "markdown-it": "^14.1.0",
     "minimist": "^1.2.8",
     "morgan": "1.10.x",
     "nunjucks": "^3.2.4",

--- a/test/cypress/integration/payment-links/start.cy.js
+++ b/test/cypress/integration/payment-links/start.cy.js
@@ -20,7 +20,10 @@ describe('The payment link start page', () => {
       external_id: productExternalId,
       reference_enabled: true,
       reference_label: referenceLabel,
-      description: 'Once payment is received your permit will be printed and posted to you. Please note that this can take up to 10 working days from receipt of payment.',
+      description: 'You can request a refund due to:\n' +
+        '\n' +
+        '* illness\n' +
+        '* deep regret\n',
       type: 'ADHOC'
     }
 
@@ -45,7 +48,8 @@ describe('The payment link start page', () => {
       cy.title().should('contain', `Make a payment - ${productName}`)
       cy.get('[data-cy=heading-caption]').should('have.text', organisationName)
       cy.get('h1').should('have.text', productName)
-      cy.get('[data-cy=product-description]').should('contain', 'Once payment is received')
+      cy.get('[data-cy=product-description]').should('contain', 'You can request a refund due to:')
+      cy.get('[data-cy=product-description]').find('ul').find('li').first().should('contain', 'illness')
     })
 
     it('should continue to the reference page when continue is clicked', () => {


### PR DESCRIPTION
Support markdown for payment link details

Add a Nunjucks filter to format markdown to HTML

This uses the markdown-it library, which is widely used in MoJ code.

Only support the following:
    - paragraphs
    - links
    - unordered lists
    - ordered lists

All other markdown will be ignored, and HTML will be escaped.

Use this Nunjucks filter to format the payment link description.

This implementation re-uses some code from https://github.com/ministryofjustice/opg-performance-data/ to add govuk-frontend styling to the rendered HTML elements.

![Screenshot 2024-10-02 at 17 21 16](https://github.com/user-attachments/assets/e5954bcb-9330-4e9e-8fa1-b509090116c3)

