### PR TITLE
PP-13234: Using latest run-amock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,13 +39,13 @@
       "devDependencies": {
         "@babel/core": "^7.23.2",
         "@babel/preset-env": "^7.23.2",
-        "@govuk-pay/run-amock": "0.0.1",
+        "@govuk-pay/run-amock": "0.0.3",
         "@pact-foundation/pact": "^12.1.1",
         "@pact-foundation/pact-core": "^14.0.5",
         "@snyk/protect": "^1.1235.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^13.8.0",
         "dotenv": "^16.3.1",
         "eslint": "8.47.x",
@@ -2095,13 +2095,13 @@
       }
     },
     "node_modules/@govuk-pay/run-amock": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.1.tgz",
-      "integrity": "sha512-IU5OqEKfOOENuX3aNtkk6OyD02dJdDx5p+9NzoK2nzCTpIqjz5gnLNg0xBPXKFD0stOEdr9vTwWc5MmcR9Yjag==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/run-amock/-/run-amock-0.0.3.tgz",
+      "integrity": "sha512-01DmzFJLGG282DStWe6B1jyh3npV6F5f6IHjdRFve1HcI5TjkcKtEYK7eeNRK9gPhPYYptjXF5zqA9eB/C3nBg==",
       "dev": true,
       "license": "MIT",
       "bin": {
-        "run-amock": "bin/run"
+        "run-amock": "bin/run.js"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "devDependencies": {
     "@babel/core": "^7.23.2",
     "@babel/preset-env": "^7.23.2",
-    "@govuk-pay/run-amock": "0.0.1",
+    "@govuk-pay/run-amock": "0.0.3",
     "@pact-foundation/pact": "^12.1.1",
     "@pact-foundation/pact-core": "^14.0.5",
     "@snyk/protect": "^1.1235.x",


### PR DESCRIPTION
## WHAT
Using the latest version of `run-amock` which uses case-sensitive query strings as we no longer have to maintain feature-compatibility with Mountebank.