### PR TITLE
PP-12244: Use shared workflow for CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,47 +12,12 @@ on:
     # Weekly schedule
     - cron: '43 7 * * 1'
 
+permissions:
+  security-events: write
+
 jobs:
   analyze:
-    name: Analyze
-    runs-on: 'ubuntu-latest'
-    timeout-minutes: 360
-    permissions:
-      # required for CodeQL to raise security issues on the repo
-      security-events: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
-        with:
-          fetch-depth: '0'
-
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@379614612a29c9e28f31f39a59013eb8012a51f0
-        with:
-          # CodeQL options: [ 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift' ]
-          languages: 'javascript-typescript'
-          config: |
-            paths:
-              - 'app/**'
-              - 'test/**'
-
-      - name: Parse Node version
-        id: parse-node-version
-        run: echo "nvmrc=$(cat .nvmrc)" >> $GITHUB_OUTPUT
-      - name: Set up Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: ${{ needs.version.outputs.node-version }}
-
-      - name: Install dependencies
-        run: npm ci
-      - name: Compile
-        run: npm run compile
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@379614612a29c9e28f31f39a59013eb8012a51f0
-        with:
-          category: "/language:javascript-typescript"
-
+    name: "Run CodeQL"
+    uses: alphagov/pay-ci/.github/workflows/_run-codeql-scan.yml@master
+    with:
+      is_node_repo: true


### PR DESCRIPTION
Part of the effort to remove duplicated workflow code across our app repositories. There is now a [shared workflow for CodeQL code scanning](https://github.com/alphagov/pay-ci/pull/1321) in the pay-ci repository.

See equivalent PR for pay-frontend: https://github.com/alphagov/pay-frontend/pull/3923
