### PR TITLE
PP-12475 Remove HTML5 shiv NPM module and references

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,16 +41,6 @@ module.exports = function (grunt) {
 
     // Copies templates and assets from external modules and dirs
     copy: {
-      html5shiv: {
-        files: [
-          {
-            expand: true,
-            cwd: 'node_modules/html5shiv/dist',
-            src: 'html5shiv.min.js',
-            dest: 'public/vendor/'
-          }
-        ]
-      },
       assets: {
         files: [
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,6 @@
         "grunt-contrib-uglify": "^5.2.2",
         "grunt-contrib-watch": "1.1.x",
         "grunt-sass": "3.1.x",
-        "html5shiv": "3.7.x",
         "lint-staged": "^13.2.3",
         "mocha": "^10.2.0",
         "nock": "13.3.x",
@@ -8333,12 +8332,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/html5shiv": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/html5shiv/-/html5shiv-3.7.3.tgz",
-      "integrity": "sha512-SZwGvLGNtgp8GbgFX7oXEp8OR1aBt5LliX6dG0kdD1kl3KhMonN0QcSa/A3TsTgFewaGCbIryQunjayWDXzxmw==",
-      "dev": true
     },
     "node_modules/htmlescape": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "grunt-contrib-uglify": "^5.2.2",
     "grunt-contrib-watch": "1.1.x",
     "grunt-sass": "3.1.x",
-    "html5shiv": "3.7.x",
     "lint-staged": "^13.2.3",
     "mocha": "^10.2.0",
     "nock": "13.3.x",


### PR DESCRIPTION
- No longer required as we no longer support the old browsers which required this.