### PR TITLE
PP-14109 Update custom branding Cypress tests

### DIFF
--- a/app/views/includes/custom.njk
+++ b/app/views/includes/custom.njk
@@ -1,7 +1,7 @@
 <header class="govuk-header" role="banner" data-module="header" data-cy="header">
   <div class="govuk-header__container govuk-width-container" data-cy="header-container">
     <div class="govuk-header__logo">
-      <span class="govuk-header__link--homepage">
+      <span class="govuk-header__link--homepage" data-cy="custom-branding-image-container">
         <span class="govuk-header__logotype">
           <img src="{{ service.customBranding.imageUrl }}" class="govuk-header__logotype-crown custom-branding-image" alt="" data-cy="custom-branding-image">
         </span>

--- a/test/cypress/integration/payment-links/start.cy.js
+++ b/test/cypress/integration/payment-links/start.cy.js
@@ -128,7 +128,16 @@ describe('The payment link start page', () => {
 
       cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(255, 255, 255)')
       cy.get('[data-cy=header-container]').should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+
+      cy.get('[data-cy=header-container]')
+        .should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+        .and('have.css', 'border-bottom-width')
+        .then((borderWidth) => {
+          expect(borderWidth).not.to.eq('0px')
+        })
+
       cy.get('[data-cy=service-name]').should('have.css', 'color', 'rgb(0, 0, 0)')
+      cy.get('[data-cy=custom-branding-image-container]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
       cy.get('[data-cy=custom-branding-image]').should('have.attr', 'src', '/public/images/custom/cypress-testing.svg')
     })
 
@@ -149,7 +158,16 @@ describe('The payment link start page', () => {
 
       cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(191, 64, 191)')
       cy.get('[data-cy=header-container]').should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+
+      cy.get('[data-cy=header-container]')
+        .should('have.css', 'border-bottom-color', 'rgb(0, 0, 0)')
+        .and('have.css', 'border-bottom-width')
+        .then((borderWidth) => {
+          expect(borderWidth).not.to.eq('0px')
+        })
+
       cy.get('[data-cy=service-name]').should('have.css', 'color', 'rgb(255, 255, 255)')
+      cy.get('[data-cy=custom-branding-image-container]').should('have.css', 'background-color', 'rgba(0, 0, 0, 0)')
       cy.get('[data-cy=custom-branding-image]').should('have.attr', 'src', '/public/images/custom/cypress-testing.svg')
     })
   })


### PR DESCRIPTION
- When testing the new branding, we identified that it caused a couple of bugs with custom branding.
- This ticket is to update custom branding tests to pick up these issues.
- This ensures that when the new branding is implemented - these tests will fail unless the bugs are fixed.
- The tests have been updated to check the following:
  - Make sure the bottom border is of the container is visible.
  - Check background colour of the logo's container.

# Current branding - tests all pass

![image](https://github.com/user-attachments/assets/a645e2ac-5c1a-4d79-8b67-01105472c2f4)


# New branding - 2 tests fail, which is what we want to happen.

Fails if the bottom border is not visible:

![image](https://github.com/user-attachments/assets/49b38afb-e8dc-4fb7-88c8-59b6e501d25a)

Fails if the background of the logo is not transparent

![image](https://github.com/user-attachments/assets/1fc782b2-dea3-4d5c-9cd7-b80c96c1730a)

