### PR TITLE
PP-13464 change h1 wording for accessibility

### DIFF
--- a/locales/cy.json
+++ b/locales/cy.json
@@ -77,7 +77,7 @@
       "pleaseEnterYour": "Cofnodwch eich"
     },
     "amount": {
-      "enterAmountToPay": "Cofnodwch swm i’w dalu"
+      "enterAmountToPay": "Nodwch y swm i'w dalu mewn punnoedd"
     },
     "confirm": {
       "checkYourDetails": "Gwiriwch eich manylion",

--- a/locales/en.json
+++ b/locales/en.json
@@ -77,7 +77,7 @@
 			"pleaseEnterYour": "Enter your"
 		},
 		"amount": {
-			"enterAmountToPay": "Enter amount to pay"
+			"enterAmountToPay": "Enter amount to pay in pounds"
 		},
 		"confirm": {
 			"checkYourDetails": "Check your details",

--- a/test/cypress/integration/payment-links/amount.cy.js
+++ b/test/cypress/integration/payment-links/amount.cy.js
@@ -30,7 +30,7 @@ describe('Amount page', () => {
       cy.visit('/pay/a-product-id/amount')
 
       cy.get('[data-cy=back-link]').should('have.attr', 'href', '/pay/a-product-id')
-      cy.get('[data-cy=label]').should('contain', 'Enter amount to pay')
+      cy.get('[data-cy=label]').should('contain', 'Enter amount to pay in pounds')
       cy.get('#payment-amount-hint').should('contain', 'Find it somewhere')
       cy.get('[data-cy=button]').should('exist')
     })


### PR DESCRIPTION
Changing the wording of h1 element to reflect accessibility best practise. 
<img width="1240" alt="Screenshot 2025-05-29 at 15 00 25" src="https://github.com/user-attachments/assets/75ea5552-dcbb-4500-8144-22c26a1ae184" />
