### PR TITLE
PP-13896 - Updating the Cypress tests to test rebranding.

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -15,9 +15,12 @@ module.exports = defineConfig({
       return require('./test/cypress/plugins')(on, config)
     },
     baseUrl: 'http://127.0.0.1:3000',
-    specPattern: './test/cypress/integration/**/*.cy.js',
+    specPattern: [
+      './test/cypress/integration/**/*.cy.js',
+      './test/cypress/integration/**/*.rebrand.js'
+    ],
     supportFile: './test/cypress/support',
     viewportHeight: 800,
     viewportWidth: 1280
-  },
+  }
 })

--- a/package.json
+++ b/package.json
@@ -40,8 +40,10 @@
     "prepublish": "npm run snyk-protect",
     "publish-pacts": "./bin/publish-pacts.js",
     "cypress:server": "run-amock --port=8000 | node --inspect -r dotenv/config config/start.js dotenv_config_path=test/cypress/test.env",
-    "cypress:test": "cypress run",
+    "cypress:test": "cypress run --spec './test/cypress/integration/**/*.cy.js'",
     "cypress:test-headed": "cypress open",
+    "cypress:server-rebrand": "run-amock --port=8000 | ENABLE_REBRAND=true node -r dotenv/config config/start.js dotenv_config_path=test/cypress/test.env",
+    "cypress:test-rebrand": "cypress run --spec './test/cypress/integration/payment-links/rebrand-header-footer.cy.rebrand.js,./test/cypress/integration/payment-links/custom-branding.cy.js'",
     "cypress:test-no-watch": "cypress open --config watchForFileChanges=false"
   },
   "lint-staged": {

--- a/test/cypress/integration/payment-links/rebrand-header-footer.cy.rebrand.js
+++ b/test/cypress/integration/payment-links/rebrand-header-footer.cy.rebrand.js
@@ -1,0 +1,43 @@
+const productStubs = require('../../stubs/products-stubs')
+const serviceStubs = require('../../stubs/service-stubs')
+
+const gatewayAccountId = 42
+const productExternalId = 'a-product-id'
+const serviceNamePath = 'a-service-name'
+const productNamePath = 'a-product-name'
+
+describe('Rebranding', () => {
+  const productOpts = {
+    gateway_account_id: gatewayAccountId,
+    external_id: productExternalId,
+    service_name_path: serviceNamePath,
+    product_name_path: productNamePath,
+    type: 'ADHOC',
+    description: null
+  }
+  it('should display the header and footer with new branding when ENABLE_REBRAND = true', () => {
+    cy.task('setupStubs', [
+      productStubs.getProductByPathStub(productOpts),
+      productStubs.getProductByExternalIdStub(productOpts),
+      serviceStubs.getServiceSuccess({
+        gatewayAccountId: gatewayAccountId
+      })
+    ])
+
+    cy.visit(`/redirect/${serviceNamePath}/${productNamePath}`)
+
+    cy.log('Should display the header with new branding')
+
+    cy.get('[data-cy=header]').should('have.css', 'background-color', 'rgb(29, 112, 184)')
+    cy.get('[data-cy=header]').should('have.css', 'color', 'rgb(255, 255, 255)')
+    cy.get('[data-cy=header]')
+      .find('.govuk-header__container')
+      .should('have.css', 'border-bottom-color', 'rgb(255, 255, 255)')
+
+    cy.log('Should display the footer with new branding')
+
+    cy.get('[data-cy=footer]')
+      .should('have.css', 'background-color', 'rgb(244, 248, 251)')
+      .should('have.css', 'border-top-color', 'rgb(29, 112, 184)')
+  })
+})


### PR DESCRIPTION
- Updating the Cypress tests to handle rebranding.
- This approach is taken from `pay-frontend` where it is already working.
- We now need 2 Cypress test suites temporarily until the new branding is live
  - Main test suite
    - Rebranding flag ENABLE_REBRAND is undefined.
    - Standard Cypress tests with the current branding.
    - Custom branding tests.
    - These are run with
      - `npm run cypress:server`
      - `npm run cypress:test`
  - Rebranding test suite
    - Rebranding flag ENABLE_REBRAND = true
    - Want to run the test to check the rebranding
    - I.e. Check that the header and footer has the new CSS styling.
    - This is a new test that is only run when ENABLE_FLAG=true.
    - Custom branding tests
      - These tests should work whether the ENABLE_REBRAND is true or false/undefined.
    - These are run with - `npm run cypress:server-rebrand` - `npm run cypress:test-rebrand`
- To stop the rebranding test running during the main test suite, it has a different file extension - cy.rebrand.js
- We use this file extension to exclude this test when the main test suite is run.
- Cypress config had to be updated to recognise this file extension.
- Once the new branding is LIVE, we can update the existing tests and go to just needing the main test suite.
- CICD will be updated to run both test suites in a future PR.