### PR TITLE
PP-13896 Add Cypress rebrand tests to Github actions

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -40,6 +40,11 @@ jobs:
     name: "Cypress"
     needs: [ install-and-compile ]
     uses: alphagov/pay-ci/.github/workflows/_run-node-cypress-tests.yml@master
+  
+  cypress-tests-rebrand:
+    name: "Cypress tests for rebranding"
+    needs: [ install-and-compile ]
+    uses: alphagov/pay-ci/.github/workflows/_run-node-cypress-tests-rebrand.yml@master
 
   pact-providers-contract-tests:
     name: "Provider tests"


### PR DESCRIPTION
- Add the step to run the Cypress rebranding tests to GHA.