### PR TITLE
PP-14242 Footer bug fix - not showing address

### DIFF
--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -14,8 +14,20 @@ class Service {
     this.name = serviceData.name
     this.serviceName = serviceData.service_name
     this.gatewayAccountIds = serviceData.gateway_account_ids
+
     this.organisationName = serviceData.merchant_details && serviceData.merchant_details.name
+
     this.merchantDetails = serviceData.merchant_details
+      ? {
+        name: serviceData.merchant_details.name,
+        addressLine1: serviceData.merchant_details.address_line1,
+        addressLine2: serviceData.merchant_details.address_line2,
+        city: serviceData.merchant_details.address_city,
+        postcode: serviceData.merchant_details.address_postcode,
+        countryName: serviceData.merchant_details.address_country
+      }
+      : undefined
+
     this.customBranding =
       serviceData.custom_branding ? {
         cssUrl: serviceData.custom_branding.css_url,

--- a/app/models/Service.class.test.js
+++ b/app/models/Service.class.test.js
@@ -1,0 +1,44 @@
+'use strict'
+
+// NPM dependencies
+const expect = require('chai').expect
+
+// Local dependencies
+const Service = require('./Service.class')
+const serviceFixtures = require('../../test/fixtures/service.fixtures')
+
+describe('Service model from service raw data', () => {
+  it('should save merchant details correctly in the service model', () => {
+    const serviceModel = new Service(serviceFixtures.validServiceResponse({
+      organisationName: 'Give Me Your Money',
+      merchant_details: {
+        address_line1: 'Clive House',
+        address_line2: '10 Downing Street',
+        address_city: 'London',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
+      }
+    }))
+
+    expect(serviceModel.organisationName).to.equal('Give Me Your Money')
+    expect(serviceModel.merchantDetails.name).to.equal('Give Me Your Money')
+    expect(serviceModel.merchantDetails.addressLine1).to.equal('Clive House')
+    expect(serviceModel.merchantDetails.addressLine2).to.equal('10 Downing Street')
+    expect(serviceModel.merchantDetails.city).to.equal('London')
+    expect(serviceModel.merchantDetails.postcode).to.equal('AW1H 9UX')
+    expect(serviceModel.merchantDetails.countryName).to.equal('GB')
+  })
+
+  it('should return merchant details as undefined when not in raw data', () => {
+    const data = {
+      external_id: '1234',
+      name: 'service name',
+      gateway_account_ids: [1],
+      custom_branding: { css_url: 'css url', image_url: 'image url' }
+    }
+
+    const serviceModel = new Service(data)
+
+    expect(serviceModel.merchantDetails).to.equal(undefined)
+  })
+})

--- a/app/views/layout.njk
+++ b/app/views/layout.njk
@@ -81,8 +81,8 @@
       {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.postcode %}
     {% endif %}
 
-    {% if service.merchantDetails.country %}
-      {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.country %}
+    {% if service.merchantDetails.countryName %}
+      {% set footerMetaText = footerMetaText + ', ' + service.merchantDetails.countryName %}
     {% endif %}
 
   {% else %}

--- a/test/cypress/integration/payment-links/footer.test.cy.js
+++ b/test/cypress/integration/payment-links/footer.test.cy.js
@@ -26,11 +26,11 @@ describe('The footer displayed on payment', () => {
         organisationName,
         merchant_details: {
           name: organisationName,
-          addressLine1: '6 starling Street',
-          addressLine2: 'Borough',
-          city: 'Swift',
-          postcode: 'AW1H 9UX',
-          country: 'United Kingdom'
+          address_line1: '6 starling Street',
+          address_line2: 'Borough',
+          address_city: 'Swift',
+          address_postcode: 'AW1H 9UX',
+          address_country: 'GB'
         }
       }
 
@@ -68,20 +68,20 @@ describe('The footer displayed on payment', () => {
 
       cy.get('[data-cy=footer]')
         .find('.govuk-footer__meta-custom')
-        .should('contain', 'Service provided by Swift Council, 6 starling Street, Borough, Swift, AW1H 9UX, United Kingdom')
+        .should('contain', 'Service provided by Swift Council, 6 starling Street, Borough, Swift, AW1H 9UX, GB')
     })
   })
 
-  it('should display the service name and address when service does not have a second line', () => {
+  it('should display the service name and address when service does not have a second address line', () => {
     const serviceOpts = {
       gatewayAccountId: gatewayAccountId,
       organisationName,
       merchant_details: {
         name: organisationName,
-        addressLine1: '6 starling Street',
-        city: 'Swift',
-        postcode: 'AW1H 9UX',
-        country: 'United Kingdom'
+        address_line1: '6 starling Street',
+        address_city: 'Swift',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
       }
     }
 
@@ -94,7 +94,7 @@ describe('The footer displayed on payment', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}`)
     cy.get('[data-cy=footer]')
       .find('.govuk-footer__meta-custom')
-      .should('contain', 'Service provided by Swift Council, 6 starling Street, Swift, AW1H 9UX, United Kingdom')
+      .should('contain', 'Service provided by Swift Council, 6 starling Street, Swift, AW1H 9UX, GB')
   })
 
   it('should not display the service details if there are no organisation for the service', () => {
@@ -120,11 +120,11 @@ describe('The footer displayed on payment', () => {
       gatewayAccountId: gatewayAccountId,
       merchant_details: {
         name: null,
-        addressLine1: '6 starling Street',
-        addressLine2: 'Borough',
-        city: 'Swift',
-        postcode: 'AW1H 9UX',
-        country: 'United Kingdom'
+        address_line1: '6 starling Street',
+        address_line2: 'Borough',
+        address_city: 'Swift',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
       }
     }
 
@@ -141,15 +141,15 @@ describe('The footer displayed on payment', () => {
       .should('not.exist')
   })
 
-  it('should display just the service name when mandatory address fields are missing', () => {
+  it('should display just the service namei and address when some address fields are missing', () => {
     const serviceOpts = {
       gatewayAccountId: gatewayAccountId,
       organisationName,
       merchant_details: {
         name: organisationName,
-        city: 'Swift',
-        postcode: 'AW1H 9UX',
-        country: 'United Kingdom'
+        address_city: 'Swift',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'GB'
       }
     }
 
@@ -162,6 +162,6 @@ describe('The footer displayed on payment', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}`)
     cy.get('[data-cy=footer]')
       .find('.govuk-footer__meta-custom')
-      .should('contain', 'Service provided by Swift Council, Swift, AW1H 9UX, United Kingdom')
+      .should('contain', 'Service provided by Swift Council, Swift, AW1H 9UX, GB')
   })
 })

--- a/test/fixtures/service.fixtures.js
+++ b/test/fixtures/service.fixtures.js
@@ -3,6 +3,7 @@
 module.exports = {
   validServiceResponse: (serviceData = {}) => {
     const defaultCustomBranding = { cssUrl: 'css url', imageUrl: 'image url' }
+
     const data = {
       external_id: serviceData.external_id || 'service-external-id',
       service_name: serviceData.service_name || { en: 'Super GOV service' },
@@ -14,13 +15,14 @@ module.exports = {
     if (serviceData.organisationName) {
       data.merchant_details = {
         name: serviceData.organisationName,
-        addressLine1: serviceData.merchant_details.addressLine1,
-        addressLine2: serviceData.merchant_details.addressLine2,
-        city: serviceData.merchant_details.city,
-        postcode: serviceData.merchant_details.postcode,
-        country: serviceData.merchant_details.country
+        address_line1: serviceData.merchant_details.address_line1,
+        address_line2: serviceData.merchant_details.address_line2,
+        address_city: serviceData.merchant_details.address_city,
+        address_postcode: serviceData.merchant_details.address_postcode,
+        address_country: serviceData.merchant_details.address_country
       }
     }
+
     return data
   }
 }


### PR DESCRIPTION
- Update service class to save merchant address in the right format when it comes back from the backend.
- The address was not being shown in the footer because it was not being saving in the right format in the service class.
- Update tests and stubs.
- The country is currently being shown as 2 digit ISO code.  This will be updated in a future PR to show the full country name.

<img width="704" height="486" alt="image" src="https://github.com/user-attachments/assets/b9b53844-9de3-4d4b-b0c8-706fb333e03b" />
