### PR TITLE
PP-14242 Footer - display full country name

### DIFF
--- a/app/models/Service.class.js
+++ b/app/models/Service.class.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const { translateAlpha2 } = require('@govuk-pay/pay-js-commons').utils.countries
+
 /**
  * @class Service
  * @property {string} externalId - The external ID of the service
@@ -24,7 +26,7 @@ class Service {
         addressLine2: serviceData.merchant_details.address_line2,
         city: serviceData.merchant_details.address_city,
         postcode: serviceData.merchant_details.address_postcode,
-        countryName: serviceData.merchant_details.address_country
+        countryName: serviceData.merchant_details.address_country ? translateAlpha2(serviceData.merchant_details.address_country) : undefined
       }
       : undefined
 

--- a/app/models/Service.class.test.js
+++ b/app/models/Service.class.test.js
@@ -26,7 +26,36 @@ describe('Service model from service raw data', () => {
     expect(serviceModel.merchantDetails.addressLine2).to.equal('10 Downing Street')
     expect(serviceModel.merchantDetails.city).to.equal('London')
     expect(serviceModel.merchantDetails.postcode).to.equal('AW1H 9UX')
-    expect(serviceModel.merchantDetails.countryName).to.equal('GB')
+    expect(serviceModel.merchantDetails.countryName).to.equal('United Kingdom')
+  })
+
+  it('when the country code is invalid then it should return undefined', () => {
+    const serviceModel = new Service(serviceFixtures.validServiceResponse({
+      organisationName: 'Give Me Your Money',
+      merchant_details: {
+        address_line1: 'Clive House',
+        address_line2: '10 Downing Street',
+        address_city: 'London',
+        address_postcode: 'AW1H 9UX',
+        address_country: 'ZZ' // ZZ is guaranteed to never be used as a country code
+      }
+    }))
+
+    expect(serviceModel.merchantDetails.countryName).to.equal(undefined)
+  })
+
+  it('when the country code is empty then it should return undefined', () => {
+    const serviceModel = new Service(serviceFixtures.validServiceResponse({
+      organisationName: 'Give Me Your Money',
+      merchant_details: {
+        address_line1: 'Clive House',
+        address_line2: '10 Downing Street',
+        address_city: 'London',
+        address_postcode: 'AW1H 9UX'
+      }
+    }))
+
+    expect(serviceModel.merchantDetails.countryName).to.equal(undefined)
   })
 
   it('should return merchant details as undefined when not in raw data', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "^7.0.10",
+        "@govuk-pay/pay-js-commons": "^7.0.12",
         "@govuk-pay/pay-js-metrics": "^1.0.14",
         "@sentry/node": "7.119.2",
         "axios": "^1.8.3",
@@ -1741,9 +1741,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.10.tgz",
-      "integrity": "sha512-aVBHr6cW1reJYnXR8Q2kPpc17uz1oa97MWZcCoaAyDxMQvGfCeW0UrC6GWClk+ifM+Us+F0AQY5S6pTiCr/iFQ==",
+      "version": "7.0.12",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.12.tgz",
+      "integrity": "sha512-zEwYqSEy5Jwgx5GUyk/YA2xMOu0GB9HR88C87SnAyhNd5pVpaeS2kuGmjBzxD48dR000nyRogtP5KTCbBOPWTA==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.6.5",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "^7.0.10",
+    "@govuk-pay/pay-js-commons": "^7.0.12",
     "@govuk-pay/pay-js-metrics": "^1.0.14",
     "@sentry/node": "7.119.2",
     "axios": "^1.8.3",

--- a/test/cypress/integration/payment-links/footer.test.cy.js
+++ b/test/cypress/integration/payment-links/footer.test.cy.js
@@ -68,7 +68,7 @@ describe('The footer displayed on payment', () => {
 
       cy.get('[data-cy=footer]')
         .find('.govuk-footer__meta-custom')
-        .should('contain', 'Service provided by Swift Council, 6 starling Street, Borough, Swift, AW1H 9UX, GB')
+        .should('contain', 'Service provided by Swift Council, 6 starling Street, Borough, Swift, AW1H 9UX, United Kingdom')
     })
   })
 
@@ -94,7 +94,7 @@ describe('The footer displayed on payment', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}`)
     cy.get('[data-cy=footer]')
       .find('.govuk-footer__meta-custom')
-      .should('contain', 'Service provided by Swift Council, 6 starling Street, Swift, AW1H 9UX, GB')
+      .should('contain', 'Service provided by Swift Council, 6 starling Street, Swift, AW1H 9UX, United Kingdom')
   })
 
   it('should not display the service details if there are no organisation for the service', () => {
@@ -162,6 +162,6 @@ describe('The footer displayed on payment', () => {
     cy.visit(`/redirect/${serviceNamePath}/${productNamePath}`)
     cy.get('[data-cy=footer]')
       .find('.govuk-footer__meta-custom')
-      .should('contain', 'Service provided by Swift Council, Swift, AW1H 9UX, GB')
+      .should('contain', 'Service provided by Swift Council, Swift, AW1H 9UX, United Kingdom')
   })
 })


### PR DESCRIPTION
- Use function from pay-js-commons to convert country code to full country name.

<img width="2070" height="1048" alt="image" src="https://github.com/user-attachments/assets/1f6cd81f-6119-41c8-addf-236cd79d1b3c" />
