### PR TITLE
PP-15339 Bump pay-js-metrics & refactor catch all route

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -95,5 +95,5 @@ module.exports.bind = function (app) {
 
   // route to gov.uk 404 page
   // this has to be the last route registered otherwise it will redirect other routes
-  app.all('*path', (req, res) => res.redirect('https://www.gov.uk/404'))
+  app.all('*splat', (req, res) => res.redirect('https://www.gov.uk/404'))
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@govuk-pay/pay-js-commons": "^7.0.51",
-        "@govuk-pay/pay-js-metrics": "^1.0.14",
+        "@govuk-pay/pay-js-metrics": "^2.0.1",
         "@sentry/node": "7.119.2",
         "axios": "1.15.2",
         "body-parser": "1.20.x",
@@ -46,7 +46,7 @@
         "@snyk/protect": "^1.1235.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^15.13.1",
         "dotenv": "^16.3.1",
         "eslint": "8.47.x",
@@ -1783,9 +1783,10 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
-      "version": "1.0.14",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-1.0.14.tgz",
-      "integrity": "sha512-UqQ6V/6xUt1N62j0ugOUGmSRfZkg1tO9OYlT9YZoDXCEPFZeMo69dDIp+LJzvJJSHMdiPXLw+y0PeME6McWuUQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-2.0.1.tgz",
+      "integrity": "sha512-t3GXcQ68B+s7AVhzM0FdIyi9wHFC1yDCDkZ+Wa2N0y0OT4nTRsq+R3cIM7dR5qk/xCWaGPL6AB7Rz3iHXNR5uQ==",
+      "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",
         "prom-client": "^14.2.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@govuk-pay/pay-js-commons": "^7.0.51",
-    "@govuk-pay/pay-js-metrics": "^1.0.14",
+    "@govuk-pay/pay-js-metrics": "^2.0.1",
     "@sentry/node": "7.119.2",
     "axios": "1.15.2",
     "body-parser": "1.20.x",

--- a/test/test-helpers/mock-session.js
+++ b/test/test-helpers/mock-session.js
@@ -11,7 +11,7 @@ module.exports = {
 
 function createAppWithSession (app, sessionData = {}) {
   const proxyApp = express()
-  proxyApp.all('*path', (req, res, next) => {
+  proxyApp.all('*splat', (req, res, next) => {
     sessionData.destroy = sinon.stub()
     sessionData.csrfSecret = sessionData.csrfSecret || '123'
     req.session = sessionData || {}


### PR DESCRIPTION
- Bump pay-js-metrics
- Change path references from '*path' to '*splat' - so that it is inline with standard conventions and our other Node apps.