### PR TITLE
PP-15165 Remove token used to run provider contract tests

### DIFF
--- a/.github/workflows/_run-tests.yml
+++ b/.github/workflows/_run-tests.yml
@@ -7,8 +7,6 @@ on:
         required: true
       pact_broker_password:
         required: true
-      repos_readonly_token:
-        required: true
 
 permissions:
   contents: read
@@ -56,7 +54,6 @@ jobs:
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
-      repos_readonly_token: ${{ secrets.repos_readonly_token }}
 
   check-docker-base-images-are-manifests:
     uses: alphagov/pay-ci/.github/workflows/_validate_docker_image_is_manifest.yml@master

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -18,7 +18,6 @@ jobs:
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
-      repos_readonly_token: ${{ secrets.repos_readonly_token }}
 
   tag-release:
     needs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,7 +12,6 @@ jobs:
     secrets:
       pact_broker_username: ${{ secrets.pact_broker_username }}
       pact_broker_password: ${{ secrets.pact_broker_password }}
-      repos_readonly_token: ${{ secrets.repos_readonly_token }}
 
   dependency-review:
     name: Dependency Review scan


### PR DESCRIPTION
## WHAT
- Removes `repos_readonly_token` as it is no longer required to run provider contract tests