### PR TITLE
BAU update pay-js packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@govuk-pay/pay-js-commons": "^7.0.58",
-        "@govuk-pay/pay-js-metrics": "^2.0.2",
+        "@govuk-pay/pay-js-commons": "^7.0.66",
+        "@govuk-pay/pay-js-metrics": "^2.0.5",
         "@sentry/node": "7.119.2",
         "axios": "1.18.0",
         "body-parser": "1.20.x",
@@ -47,7 +47,7 @@
         "@snyk/protect": "^1.1235.x",
         "chai": "^4.3.7",
         "cheerio": "^1.0.0-rc.12",
-        "chokidar-cli": "*",
+        "chokidar-cli": "latest",
         "cypress": "^15.16.0",
         "dotenv": "^16.3.1",
         "eslint": "8.47.x",
@@ -1836,12 +1836,12 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-commons": {
-      "version": "7.0.59",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.59.tgz",
-      "integrity": "sha512-HNwJyH3dyzmboWWUmutbDhbUYVb9KGDgVcSijbQb8Lo1hYDzcbnu8AyAyKnAskImK95O3rrcWSlQa38DkFj0Yw==",
+      "version": "7.0.66",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-commons/-/pay-js-commons-7.0.66.tgz",
+      "integrity": "sha512-lmr0+90clPpQVlJF2lbgUXeAlcOtRY+I+iaEgiIxxQR1COg49FYBBX2LT6e/vYXhEFxeVFj1uMDcHHkFsBzGFA==",
       "license": "MIT",
       "dependencies": {
-        "axios": "1.16.0",
+        "axios": "1.18.0",
         "csrf": "^3.1.0",
         "express-rate-limit": "^8.1.0",
         "lodash": "4.18.1",
@@ -1907,9 +1907,9 @@
       }
     },
     "node_modules/@govuk-pay/pay-js-metrics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-2.0.3.tgz",
-      "integrity": "sha512-i7H71eBWS9dJUwqV1tsKoBfs3bPKg2rWeKsLADb7QmF9a21cgUkhQkx0iz/oeNgWCma/DnKZp2Ex8wUkAdz08g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@govuk-pay/pay-js-metrics/-/pay-js-metrics-2.0.5.tgz",
+      "integrity": "sha512-SIBPWBTU+9HqBmEBsqNHTlQrqzX9BWHpiJ2fZpYxDftHV5ygtezjnY9Dq/fRMX4TXjIeprPuNHPaMP7hWq1xMg==",
       "license": "MIT",
       "dependencies": {
         "on-finished": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     ]
   },
   "dependencies": {
-    "@govuk-pay/pay-js-commons": "^7.0.58",
-    "@govuk-pay/pay-js-metrics": "^2.0.2",
+    "@govuk-pay/pay-js-commons": "^7.0.66",
+    "@govuk-pay/pay-js-metrics": "^2.0.5",
     "@sentry/node": "7.119.2",
     "axios": "1.18.0",
     "body-parser": "1.20.x",


### PR DESCRIPTION
pay-js-commons and pay-js-metrics are behind the real releases. Update package to the latest ones.